### PR TITLE
Add UI config flow with Zeroconf discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,17 +46,23 @@ systemctl start websocketd
 
 ## Configuration
 
-Add the following to your `configuration.yaml`:
+After installation, go to **Settings → Devices & Services → Add Integration** and search for "GARDENA smart local". Enter the IP address or hostname of your gateway and the password.
+
+The gateway can also be discovered automatically via Zeroconf — look for a notification in Home Assistant after installation.
+
+> [!TIP]
+> The password is the first block of the gateway ID printed on the back of the device.
+> (example: `0824b95b-996c-48f7-83dc-d2d1bac08e7e` → password: `0824b95b`)
+
+### YAML configuration (legacy)
+
+Manual YAML configuration is still supported:
 
 ```yaml
 gardena_smart_local_preview:
   host: 192.168.1.100  # IP address or hostname of your GARDENA smart Gateway
   password: 0824b95b   # First eight characters of the gateway's ID
 ```
-
-> [!TIP]
-> The password is the first block of the gateway ID printed on the back of the device.
-> (example: `0824b95b-996c-48f7-83dc-d2d1bac08e7e` → password: `0824b95b`)
 
 After adding the configuration, restart Home Assistant.
 

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -13,6 +13,7 @@ from homeassistant.const import (
 )
 import homeassistant.helpers.config_validation as cv
 
+from . import config_flow as config_flow
 from .const import DEFAULT_PORT, DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -1,13 +1,172 @@
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
-from homeassistant.helpers.typing import ConfigType
+import base64
+import logging
 
-from .const import DOMAIN
+import aiohttp
+import voluptuous as vol
+
+from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.helpers.typing import ConfigType
+from homeassistant.util.ssl import get_default_no_verify_context
+
+from .const import DEFAULT_PORT, DOMAIN
+
+_LOGGER = logging.getLogger(__name__)
 
 
 class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
 
+    def __init__(self) -> None:
+        self._discovered_host: str | None = None
+        self._discovered_port: int = DEFAULT_PORT
+
+    async def async_step_user(self, user_input: dict | None = None) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            await self.async_set_unique_id(user_input[CONF_HOST])
+            self._abort_if_unique_id_configured()
+
+            error = await _async_try_connect(
+                user_input[CONF_HOST],
+                user_input[CONF_PORT],
+                user_input[CONF_PASSWORD],
+            )
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_create_entry(
+                    title=user_input[CONF_HOST],
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST): str,
+                    vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
+                    vol.Optional(CONF_PASSWORD, default=""): str,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_zeroconf(
+        self, discovery_info: ZeroconfServiceInfo
+    ) -> ConfigFlowResult:
+        name = discovery_info.hostname.removesuffix(".local.")
+        host = discovery_info.host
+        port = discovery_info.port or DEFAULT_PORT
+
+        await self.async_set_unique_id(name)
+        self._abort_if_unique_id_configured()
+
+        self._discovered_host = host
+        self._discovered_port = port
+        self.context["title_placeholders"] = {"name": name, "host": host}
+
+        return await self.async_step_discovery_confirm()
+
+    async def async_step_discovery_confirm(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            error = await _async_try_connect(
+                user_input[CONF_HOST],
+                user_input[CONF_PORT],
+                user_input.get(CONF_PASSWORD, ""),
+            )
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_create_entry(
+                    title=self.context["title_placeholders"]["name"],
+                    data=user_input,
+                )
+
+        return self.async_show_form(
+            step_id="discovery_confirm",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=self._discovered_host): str,
+                    vol.Optional(CONF_PORT, default=self._discovered_port): int,
+                    vol.Optional(CONF_PASSWORD, default=""): str,
+                }
+            ),
+            description_placeholders={
+                "name": self.context["title_placeholders"]["name"],
+            },
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        entry = self._get_reconfigure_entry()
+
+        if user_input is not None:
+            error = await _async_try_connect(
+                user_input[CONF_HOST],
+                user_input[CONF_PORT],
+                user_input.get(CONF_PASSWORD, ""),
+            )
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(entry, data=user_input)
+
+        return self.async_show_form(
+            step_id="reconfigure",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_HOST, default=entry.data.get(CONF_HOST, "")): str,
+                    vol.Optional(
+                        CONF_PORT, default=entry.data.get(CONF_PORT, DEFAULT_PORT)
+                    ): int,
+                    vol.Optional(
+                        CONF_PASSWORD, default=entry.data.get(CONF_PASSWORD, "")
+                    ): str,
+                }
+            ),
+            errors=errors,
+        )
+
     async def async_step_import(self, import_data: ConfigType) -> ConfigFlowResult:
-        await self.async_set_unique_id(DOMAIN)
+        await self.async_set_unique_id(import_data[CONF_HOST])
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="GARDENA smart local", data=import_data)
+
+
+async def _async_try_connect(host: str, port: int, password: str) -> str | None:
+    ssl_context = get_default_no_verify_context()
+
+    auth_b64 = base64.b64encode(f"_:{password}".encode()).decode("ascii")
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.ws_connect(
+                f"wss://{host}:{port}",
+                ssl=ssl_context,
+                headers={"Authorization": f"Basic {auth_b64}"},
+                timeout=aiohttp.ClientTimeout(total=10),
+            ) as ws:
+                await ws.close()
+    except aiohttp.WSServerHandshakeError as err:
+        if err.status == 401:
+            return "invalid_auth"
+        _LOGGER.debug("Handshake error connecting to %s:%s", host, port, exc_info=True)
+        return "cannot_connect"
+    except (aiohttp.ClientConnectionError, TimeoutError, OSError):
+        _LOGGER.debug("Error connecting to %s:%s", host, port, exc_info=True)
+        return "cannot_connect"
+    except Exception:
+        _LOGGER.exception("Unexpected error connecting to %s:%s", host, port)
+        return "unknown"
+
+    return None

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -1,10 +1,10 @@
 import asyncio
 import base64
 import logging
-import ssl
 import aiohttp
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.ssl import get_default_no_verify_context
 
 from gardena_smart_local_api.devices import (
     Device,
@@ -54,9 +54,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
     async def async_connect(self) -> None:
         if self._ssl_context is None:
-            self._ssl_context = await self.hass.async_add_executor_job(
-                self._create_ssl_context
-            )
+            self._ssl_context = get_default_no_verify_context()
         self._task = self.hass.async_create_background_task(
             self._ws_loop(), "gardena_smart_local_preview_websocket"
         )
@@ -68,13 +66,6 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 await self._task
             except asyncio.CancelledError:
                 pass
-
-    def _create_ssl_context(self) -> ssl.SSLContext:
-        """Create an insecure SSL context for self-signed certificates."""
-        context = ssl.create_default_context()
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_NONE
-        return context
 
     async def _ws_loop(self) -> None:
         while True:

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -1,0 +1,53 @@
+{
+  "config": {
+    "step": {
+      "user": {
+        "title": "Connect to GARDENA smart Gateway",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "password": "Password"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your GARDENA smart Gateway",
+          "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
+        }
+      },
+      "discovery_confirm": {
+        "title": "GARDENA smart Gateway found",
+        "description": "Do you want to set up the GARDENA smart Gateway **{name}**?",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "password": "Password"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your GARDENA smart Gateway",
+          "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
+        }
+      },
+      "reconfigure": {
+        "title": "Update GARDENA smart Gateway settings",
+        "data": {
+          "host": "Host",
+          "port": "Port",
+          "password": "Password"
+        },
+        "data_description": {
+          "host": "IP address or hostname of your GARDENA smart Gateway",
+          "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
+        }
+      }
+    },
+    "error": {
+      "cannot_connect": "Failed to connect to the gateway",
+      "invalid_auth": "Invalid password",
+      "unknown": "Unexpected error"
+    },
+    "abort": {
+      "already_configured": "Gateway is already configured",
+      "already_in_progress": "It seems the gateway has been autodetected, click \"Add\" on discovered integration instead",
+      "reconfigure_successful": "GARDENA smart Gateway settings updated"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `async_step_user` for manual setup via **Settings → Devices & Services → Add Integration**
- Adds `async_step_zeroconf` for automatic discovery using the existing `_gardena-smart._tcp.local.` advertisement in the manifest
- Validates the WebSocket connection (distinguishing `cannot_connect` vs `invalid_auth`) before creating the entry
- Adds `translations/en.json` with field labels and password hint (first block of gateway ID)
- Updates README to document UI setup as the primary method, keeping YAML as legacy

## Test plan

- [ ] Manual setup: add integration via UI, enter host/port/password, verify connection validation works for wrong host and wrong password
- [ ] Zeroconf: ensure gateway is discovered automatically and confirmation step pre-fills host
- [ ] YAML import still works without regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)