### PR TITLE
Unify entity naming with has_entity_name pattern

### DIFF
--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -42,6 +42,8 @@ async def async_setup_entry(
 class GardenaIdentifyButton(
     CoordinatorEntity[GardenaSmartLocalCoordinator], ButtonEntity
 ):
+    _attr_has_entity_name = True
+
     def __init__(
         self, coordinator: GardenaSmartLocalCoordinator, device: object
     ) -> None:

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -12,6 +12,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
+from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,7 +46,7 @@ class GardenaIdentifyButton(
     _attr_has_entity_name = True
 
     def __init__(
-        self, coordinator: GardenaSmartLocalCoordinator, device: object
+        self, coordinator: GardenaSmartLocalCoordinator, device: Device
     ) -> None:
         super().__init__(coordinator)
         self._device = device
@@ -54,7 +55,7 @@ class GardenaIdentifyButton(
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -67,7 +67,7 @@ class GardenaButtonConfigTime(
         self._attr_name = "Button Time"
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -48,6 +48,7 @@ async def async_setup_entry(
 class GardenaButtonConfigTime(
     CoordinatorEntity[GardenaSmartLocalCoordinator], NumberEntity
 ):
+    _attr_has_entity_name = True
     _attr_native_min_value = 0
     _attr_native_max_value = 90
     _attr_native_step = 1
@@ -63,9 +64,16 @@ class GardenaButtonConfigTime(
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_button_config_time"
-        self._attr_name = f"GARDENA {device.model_definition.name} Button Time"
+        self._attr_name = "Button Time"
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
+            name=f"GARDENA {device.model_definition.name}",
+            manufacturer=device.manufacturer,
+            model=device.model_definition.name,
+            model_id=device.model_definition.model_number,
+            sw_version=device.software_version,
+            hw_version=device.hardware_version,
+            serial_number=device.serial_number,
         )
 
     @property

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -84,6 +84,8 @@ async def async_setup_entry(
 class GardenaTemperatureSensor(
     CoordinatorEntity[GardenaSmartLocalCoordinator], SensorEntity
 ):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -92,13 +94,20 @@ class GardenaTemperatureSensor(
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_temperature"
-        self._attr_name = f"GARDENA {device.model_definition.name} Temperature"
+        self._attr_name = "Temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
+            name=f"GARDENA {device.model_definition.name}",
+            manufacturer=device.manufacturer,
+            model=device.model_definition.name,
+            model_id=device.model_definition.model_number,
+            sw_version=device.software_version,
+            hw_version=device.hardware_version,
+            serial_number=device.serial_number,
         )
 
     @property
@@ -120,6 +129,8 @@ class GardenaTemperatureSensor(
 class GardenaSoilMoistureSensor(
     CoordinatorEntity[GardenaSmartLocalCoordinator], SensorEntity
 ):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -128,13 +139,20 @@ class GardenaSoilMoistureSensor(
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_soil_moisture"
-        self._attr_name = f"GARDENA {device.model_definition.name} Soil Moisture"
+        self._attr_name = "Soil Moisture"
         self._attr_device_class = SensorDeviceClass.MOISTURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
+            name=f"GARDENA {device.model_definition.name}",
+            manufacturer=device.manufacturer,
+            model=device.model_definition.name,
+            model_id=device.model_definition.model_number,
+            sw_version=device.software_version,
+            hw_version=device.hardware_version,
+            serial_number=device.serial_number,
         )
 
     @property
@@ -154,6 +172,8 @@ class GardenaSoilMoistureSensor(
 
 
 class GardenaLightSensor(CoordinatorEntity[GardenaSmartLocalCoordinator], SensorEntity):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -162,13 +182,20 @@ class GardenaLightSensor(CoordinatorEntity[GardenaSmartLocalCoordinator], Sensor
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_light"
-        self._attr_name = f"GARDENA {device.model_definition.name} Light"
+        self._attr_name = "Light"
         self._attr_device_class = SensorDeviceClass.ILLUMINANCE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = LIGHT_LUX
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
+            name=f"GARDENA {device.model_definition.name}",
+            manufacturer=device.manufacturer,
+            model=device.model_definition.name,
+            model_id=device.model_definition.model_number,
+            sw_version=device.software_version,
+            hw_version=device.hardware_version,
+            serial_number=device.serial_number,
         )
 
     @property
@@ -190,6 +217,8 @@ class GardenaLightSensor(CoordinatorEntity[GardenaSmartLocalCoordinator], Sensor
 class GardenaBatterySensor(
     CoordinatorEntity[GardenaSmartLocalCoordinator], SensorEntity
 ):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -198,13 +227,20 @@ class GardenaBatterySensor(
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_battery"
-        self._attr_name = f"GARDENA {device.model_definition.name} Battery"
+        self._attr_name = "Battery"
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
+            name=f"GARDENA {device.model_definition.name}",
+            manufacturer=device.manufacturer,
+            model=device.model_definition.name,
+            model_id=device.model_definition.model_number,
+            sw_version=device.software_version,
+            hw_version=device.hardware_version,
+            serial_number=device.serial_number,
         )
 
     @property
@@ -226,6 +262,8 @@ class GardenaBatterySensor(
 class GardenaRfLinkQualitySensor(
     CoordinatorEntity[GardenaSmartLocalCoordinator], SensorEntity
 ):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -234,13 +272,20 @@ class GardenaRfLinkQualitySensor(
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_rf_link_quality"
-        self._attr_name = f"GARDENA {device.model_definition.name} RF Link Quality"
+        self._attr_name = "RF Link Quality"
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
+            name=f"GARDENA {device.model_definition.name}",
+            manufacturer=device.manufacturer,
+            model=device.model_definition.name,
+            model_id=device.model_definition.model_number,
+            sw_version=device.software_version,
+            hw_version=device.hardware_version,
+            serial_number=device.serial_number,
         )
 
     @property

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -101,7 +101,7 @@ class GardenaTemperatureSensor(
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,
@@ -146,7 +146,7 @@ class GardenaSoilMoistureSensor(
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,
@@ -189,7 +189,7 @@ class GardenaLightSensor(CoordinatorEntity[GardenaSmartLocalCoordinator], Sensor
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,
@@ -234,7 +234,7 @@ class GardenaBatterySensor(
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,
@@ -279,7 +279,7 @@ class GardenaRfLinkQualitySensor(
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -44,6 +44,8 @@ async def async_setup_entry(
 
 
 class GardenaPowerSwitch(CoordinatorEntity[GardenaSmartLocalCoordinator], SwitchEntity):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -52,11 +54,11 @@ class GardenaPowerSwitch(CoordinatorEntity[GardenaSmartLocalCoordinator], Switch
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_switch"
-        self._attr_name = f"GARDENA {device.model_definition.name}"
+        self._attr_name = None
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=self._attr_name,
+            name=f"GARDENA {device.model_definition.name}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -58,7 +58,7 @@ class GardenaPowerSwitch(CoordinatorEntity[GardenaSmartLocalCoordinator], Switch
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -59,7 +59,7 @@ class GardenaValve(CoordinatorEntity[GardenaSmartLocalCoordinator], ValveEntity)
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=f"GARDENA {device.model_definition.name}",
+            name=f"GARDENA {device.model_definition.name} {device.serial_number}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -41,6 +41,8 @@ async def async_setup_entry(
 
 
 class GardenaValve(CoordinatorEntity[GardenaSmartLocalCoordinator], ValveEntity):
+    _attr_has_entity_name = True
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
@@ -49,7 +51,7 @@ class GardenaValve(CoordinatorEntity[GardenaSmartLocalCoordinator], ValveEntity)
         super().__init__(coordinator)
         self._device = device
         self._attr_unique_id = f"{device.id}_valve"
-        self._attr_name = f"GARDENA {device.model_definition.name}"
+        self._attr_name = None
         self._attr_reports_position = False
         self._attr_supported_features = (
             ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
@@ -57,7 +59,7 @@ class GardenaValve(CoordinatorEntity[GardenaSmartLocalCoordinator], ValveEntity)
 
         self._attr_device_info = dr.DeviceInfo(
             identifiers={(DOMAIN, device.id)},
-            name=self._attr_name,
+            name=f"GARDENA {device.model_definition.name}",
             manufacturer=device.manufacturer,
             model=device.model_definition.name,
             model_id=device.model_definition.model_number,


### PR DESCRIPTION
## Summary

- Add `_attr_has_entity_name = True` to all entity classes so HA composes entity names from device name + role automatically
- `_attr_name` now holds only the entity role (e.g. `"Temperature"`, `"Identify"`) or `None` for primary entities (valve, switch)
- `DeviceInfo` always has an explicit `name=f"GARDENA {model} {serial}"` — including serial number to distinguish devices of the same model
- Sensor and number entities previously only had `identifiers` in `DeviceInfo`; they now also carry full device metadata (manufacturer, model, hw/sw/serial)
- Fix `button.py` device type annotation from `object` to `Device`

## Test plan

- [ ] Verify entity names display correctly in HA UI for valve, switch, sensor, number, and button entities
- [ ] Verify two devices of the same model show distinct names (serial suffix)
- [ ] Verify device registry entries for sensor-only devices have full metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)