### PR TITLE
Add frost warning binary sensor

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -18,6 +18,7 @@ from .const import DEFAULT_PORT, DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 
 PLATFORMS: list[Platform] = [
+    Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.LAWN_MOWER,
     Platform.NUMBER,

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.binary_sensor import (
+    BinarySensorDeviceClass,
+    BinarySensorEntity,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import GardenaSmartLocalCoordinator
+from .entity import GardenaEntity
+from gardena_smart_local_api.devices.device import Device
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    known_frost_devices: set[str] = set()
+
+    def _add_new_devices() -> None:
+        if not coordinator.data:
+            return
+        new_entities = []
+        for device in coordinator.data.values():
+            if (
+                hasattr(device, "has_frost_warning")
+                and device.id not in known_frost_devices
+            ):
+                known_frost_devices.add(device.id)
+                new_entities.append(GardenaFrostWarningSensor(coordinator, device))
+                _LOGGER.info(
+                    "Adding new frost warning sensor entity for device %s", device.id
+                )
+        if new_entities:
+            async_add_entities(new_entities)
+
+    coordinator.async_add_listener(_add_new_devices)
+
+
+class GardenaFrostWarningSensor(GardenaEntity, BinarySensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Device,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_frost_warning"
+        self._attr_name = "Frost Warning"
+        self._attr_device_class = BinarySensorDeviceClass.COLD
+        self._attr_icon = "mdi:snowflake-alert"
+
+    @property
+    def is_on(self) -> bool | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        return device.has_frost_warning


### PR DESCRIPTION
## Summary
- Adds a `GardenaFrostWarningSensor` binary sensor entity for devices that support frost warnings
- Uses `BinarySensorDeviceClass.COLD` and `mdi:snowflake-alert` icon

## Test plan
- [ ] Verify frost warning sensor appears in HA for compatible devices
- [ ] Verify icon displays correctly
- [ ] Verify sensor state reflects `has_frost_warning` from device

🤖 Generated with [Claude Code](https://claude.com/claude-code)