### PR TITLE
Add icons and device class to entities

### DIFF
--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -46,6 +46,7 @@ class GardenaIdentifyButton(GardenaEntity, ButtonEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_identify"
         self._attr_name = "Identify"
+        self._attr_icon = "mdi:crosshairs-gps"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_press(self) -> None:

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -60,6 +60,7 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_button_config_time"
         self._attr_name = "Button Time"
+        self._attr_icon = "mdi:timer-outline"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -177,6 +177,7 @@ class GardenaRfLinkQualitySensor(GardenaEntity, SensorEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_rf_link_quality"
         self._attr_name = "RF Link Quality"
+        self._attr_icon = "mdi:signal"
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
         self._attr_entity_category = EntityCategory.DIAGNOSTIC

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from homeassistant.components.switch import SwitchEntity
+from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -51,6 +51,7 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_switch"
         self._attr_name = None
+        self._attr_device_class = SwitchDeviceClass.OUTLET
 
     @property
     def is_on(self) -> bool | None:


### PR DESCRIPTION
## Summary

- `GardenaPowerSwitch`: `SwitchDeviceClass.OUTLET` statt generischem Switch-Icon
- `GardenaRfLinkQualitySensor`: `mdi:signal` (kein Device Class → kein Auto-Icon)
- `GardenaIdentifyButton`: `mdi:crosshairs-gps`
- `GardenaButtonConfigTime`: `mdi:timer-outline`

## Test plan

- [ ] Power Adapter zeigt Steckdosen-Icon in HA
- [ ] RF Link Quality zeigt Signal-Icon
- [ ] Identify Button zeigt Crosshairs-Icon
- [ ] Button Time zeigt Timer-Icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)