### PR TITLE
Add pump (22538) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,27 +73,28 @@ After adding the configuration, restart Home Assistant.
 
 ## Supported Devices
 
-| Device                                | Article no.                                | Entities                                                    |
-| ------------------------------------- | ------------------------------------------ | ----------------------------------------------------------- |
-| GARDENA smart Water Control           | 19031-20                                   | Valve, temperature, battery, RF link quality                |
-| GARDENA smart Water Control           | 19033-20                                   | Valve, battery                                              |
-| GARDENA smart Dual Water Control      | 19034-20                                   | Valve, battery                                              |
-| GARDENA smart Pipeline Water Control  | 19050-20                                   | Valve, battery                                              |
-| GARDENA smart Irrigation Control      | 19032-20                                   | Valve, RF link quality                                      |
-| GARDENA smart Irrigation Control      | 19035-20                                   | Valve                                                       |
-| GARDENA smart Sensor                  | 19030-20                                   | Temperature, soil moisture, light, battery, RF link quality |
-| GARDENA smart Sensor II               | 19040-20                                   | Temperature, soil moisture, battery, RF link quality        |
-| GARDENA smart Power Adapter           | 19095-20                                   | Switch                                                      |
-| GARDENA smart SILENO                  | 19060-20, 19060-60                         | Lawn mower                                                  |
-| GARDENA smart SILENO+                 | 19061-20, 19061-60, 19064-60, 19065-60     | Lawn mower                                                  |
-| GARDENA smart SILENO city             | 19066-20, 19069-20                         | Lawn mower                                                  |
-| GARDENA smart SILENO life             | 19113-20, 19114-20, 19115-20               | Lawn mower                                                  |
-| GARDENA smart SILENO city (with LONA) | 19602-66, 19603-60, 19605-60               | Lawn mower                                                  |
-| GARDENA smart SILENO life (with LONA) | 19701-60, 19702-60, 19703-66, 19704-60     | Lawn mower                                                  |
-| GARDENA smart SILENO pro              | 19802-20, 19802-22                         | Lawn mower                                                  |
-| GARDENA smart SILENO max              | 19901-22                                   | Lawn mower                                                  |
-| GARDENA smart SILENO free             | 19921-22, 19922-22, 19923-22               | Lawn mower                                                  |
-| Flymo UltraLife                       | 970620501, 970620701, 970715101, 970715201 | Lawn mower                                                  |
+| Device                                     | Article no.                                | Entities                                                    |
+| ------------------------------------------ | ------------------------------------------ | ----------------------------------------------------------- |
+| GARDENA smart Water Control                | 19031-20                                   | Valve, temperature, battery, RF link quality                |
+| GARDENA smart Water Control                | 19033-20                                   | Valve, battery                                              |
+| GARDENA smart Dual Water Control           | 19034-20                                   | Valve, battery                                              |
+| GARDENA smart Pipeline Water Control       | 19050-20                                   | Valve, battery                                              |
+| GARDENA smart Irrigation Control           | 19032-20                                   | Valve, RF link quality                                      |
+| GARDENA smart Irrigation Control           | 19035-20                                   | Valve                                                       |
+| GARDENA smart Automatic Home & Garden Pump | 19080-20                                   | Switch, outlet pressure, outlet temperature, flow rate, total flow, flow since reset, pump state, operating mode, turn-on pressure, dripping alert timeout, reset flow / valve errors / temperature min-max |
+| GARDENA smart Sensor                       | 19030-20                                   | Temperature, soil moisture, light, battery, RF link quality |
+| GARDENA smart Sensor II                    | 19040-20                                   | Temperature, soil moisture, battery, RF link quality        |
+| GARDENA smart Power Adapter                | 19095-20                                   | Switch                                                      |
+| GARDENA smart SILENO                       | 19060-20, 19060-60                         | Lawn mower                                                  |
+| GARDENA smart SILENO+                      | 19061-20, 19061-60, 19064-60, 19065-60     | Lawn mower                                                  |
+| GARDENA smart SILENO city                  | 19066-20, 19069-20                         | Lawn mower                                                  |
+| GARDENA smart SILENO life                  | 19113-20, 19114-20, 19115-20               | Lawn mower                                                  |
+| GARDENA smart SILENO city (with LONA)      | 19602-66, 19603-60, 19605-60               | Lawn mower                                                  |
+| GARDENA smart SILENO life (with LONA)      | 19701-60, 19702-60, 19703-66, 19704-60     | Lawn mower                                                  |
+| GARDENA smart SILENO pro                   | 19802-20, 19802-22                         | Lawn mower                                                  |
+| GARDENA smart SILENO max                   | 19901-22                                   | Lawn mower                                                  |
+| GARDENA smart SILENO free                  | 19921-22, 19922-22, 19923-22               | Lawn mower                                                  |
+| Flymo UltraLife                            | 970620501, 970620701, 970715101, 970715201 | Lawn mower                                                  |
 
 ## Not Supported Devices
 

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -36,6 +36,7 @@ PLATFORMS: list[Platform] = [
     Platform.BUTTON,
     Platform.LAWN_MOWER,
     Platform.NUMBER,
+    Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
     Platform.VALVE,

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -15,6 +15,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
+from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -26,11 +27,13 @@ async def async_setup_entry(
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
+    known_pump_devices: set[str] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
         known_devices.intersection_update(coordinator.data)
+        known_pump_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if hasattr(device, "build_identify_obj") and device.id not in known_devices:
@@ -40,6 +43,17 @@ async def async_setup_entry(
                     GardenaIdentifyButton(coordinator, device)
                 )
                 _LOGGER.info("Adding identify button for device %s", device.id)
+            if isinstance(device, Pump) and device.id not in known_pump_devices:
+                known_pump_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).extend(
+                    [
+                        GardenaPumpResetFlowButton(coordinator, device),
+                        GardenaPumpResetValveErrorsButton(coordinator, device),
+                        GardenaPumpResetTemperatureMinMaxButton(coordinator, device),
+                    ]
+                )
+                _LOGGER.info("Adding pump reset buttons for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -62,3 +76,48 @@ class GardenaIdentifyButton(GardenaEntity, ButtonEntity):
             self._device.build_identify_obj(),
         )
         _LOGGER.info("Sent identify request for device %s", self._device.id)
+
+
+class GardenaPumpResetFlowButton(GardenaEntity, ButtonEntity):
+    def __init__(self, coordinator: GardenaSmartLocalCoordinator, device: Pump) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_reset_flow"
+        self._attr_name = "Reset Resettable Flow"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_press(self) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_reset_flow_resettable_obj(),
+        )
+        _LOGGER.info("Reset resettable flow for device %s", self._device.id)
+
+
+class GardenaPumpResetValveErrorsButton(GardenaEntity, ButtonEntity):
+    def __init__(self, coordinator: GardenaSmartLocalCoordinator, device: Pump) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_reset_valve_errors"
+        self._attr_name = "Reset Valve Errors"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_press(self) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_reset_all_valve_errors_obj(),
+        )
+        _LOGGER.info("Reset valve errors for device %s", self._device.id)
+
+
+class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
+    def __init__(self, coordinator: GardenaSmartLocalCoordinator, device: Pump) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_reset_temperature_min_max"
+        self._attr_name = "Reset Temperature Min/Max"
+        self._attr_entity_category = EntityCategory.CONFIG
+
+    async def async_press(self) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_reset_outlet_temperature_min_max_obj(),
+        )
+        _LOGGER.info("Reset temperature min/max for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
-  "requirements": ["gardena-smart-local-api==0.0.9"],
   "version": "0.0.5",
+  "requirements": ["gardena-smart-local-api==0.0.10"],
   "zeroconf": ["_gardena-smart._tcp.local."]
 }

--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
-  "version": "0.0.5",
   "requirements": ["gardena-smart-local-api==0.0.10"],
+  "version": "0.0.6",
   "zeroconf": ["_gardena-smart._tcp.local."]
 }

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -8,13 +8,14 @@ import logging
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfTime
+from homeassistant.const import EntityCategory, UnitOfTime, UnitOfPressure
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
+from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -45,6 +46,16 @@ async def async_setup_entry(
                 _LOGGER.info(
                     "Adding new button config time entity for device %s", device.id
                 )
+            elif isinstance(device, Pump) and device.id not in known_devices:
+                known_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).extend(
+                    [
+                        GardenaPumpTurnOnPressure(coordinator, device),
+                        GardenaPumpDrippingAlert(coordinator, device),
+                    ]
+                )
+                _LOGGER.info("Adding new pump number entities for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -86,6 +97,78 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         )
         _LOGGER.info(
             "Set button config time for device %s to %s minutes",
+            self._device.id,
+            int(value),
+        )
+
+
+class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
+    _attr_native_min_value = 0.0
+    _attr_native_max_value = 10.0
+    _attr_native_step = 0.1
+    _attr_native_unit_of_measurement = UnitOfPressure.BAR
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_turn_on_pressure"
+        self._attr_name = "Turn-On Pressure"
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        return device.turn_on_pressure
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_set_turn_on_pressure_obj(value),
+        )
+        _LOGGER.info(
+            "Set turn-on pressure for device %s to %s bar",
+            self._device.id,
+            value,
+        )
+
+
+class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
+    _attr_native_min_value = 0
+    _attr_native_max_value = 3600
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_dripping_alert"
+        self._attr_name = "Dripping Alert Timeout"
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        return device.dripping_alert
+
+    async def async_set_native_value(self, value: float) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_set_dripping_alert_obj(int(value)),
+        )
+        _LOGGER.info(
+            "Set dripping alert timeout for device %s to %s seconds",
             self._device.id,
             int(value),
         )

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import GardenaSmartLocalCoordinator
+from .entity import GardenaEntity, find_device_subentry_id
+from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
+
+_LOGGER = logging.getLogger(__name__)
+
+_MODE_TO_OPTION: dict[PumpOperatingMode, str] = {
+    PumpOperatingMode.SCHEDULED: "scheduled",
+    PumpOperatingMode.AUTOMATIC: "automatic",
+}
+_OPTION_TO_MODE: dict[str, PumpOperatingMode] = {
+    v: k for k, v in _MODE_TO_OPTION.items()
+}
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
+    known_devices: set[str] = set()
+
+    def _add_new_devices() -> None:
+        if not coordinator.data:
+            return
+        known_devices.intersection_update(coordinator.data)
+        entities_by_subentry_id: dict[str | None, list] = {}
+        for device in coordinator.data.values():
+            if isinstance(device, Pump) and device.id not in known_devices:
+                known_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPumpOperatingModeSelect(coordinator, device)
+                )
+                _LOGGER.info("Adding operating mode select for device %s", device.id)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
+
+    coordinator.async_add_listener(_add_new_devices)
+
+
+class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
+    _attr_options = list(_OPTION_TO_MODE.keys())
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_operating_mode"
+        self._attr_name = "Operating Mode"
+
+    @property
+    def current_option(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        mode = device.operating_mode
+        return _MODE_TO_OPTION.get(mode) if mode is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        mode = _OPTION_TO_MODE[option]
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_set_operating_mode_obj(mode),
+        )
+        _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -12,13 +12,22 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import LIGHT_LUX, PERCENTAGE, EntityCategory, UnitOfTemperature
+from homeassistant.const import (
+    LIGHT_LUX,
+    PERCENTAGE,
+    EntityCategory,
+    UnitOfTemperature,
+    UnitOfPressure,
+    UnitOfVolumeFlowRate,
+    UnitOfVolume,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
+from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +43,7 @@ async def async_setup_entry(
     known_light_devices: set[str] = set()
     known_battery_devices: set[str] = set()
     known_rf_link_devices: set[str] = set()
+    known_pump_devices: set[str] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
@@ -44,6 +54,7 @@ async def async_setup_entry(
             known_light_devices,
             known_battery_devices,
             known_rf_link_devices,
+            known_pump_devices,
         ):
             cache.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
@@ -86,6 +97,19 @@ async def async_setup_entry(
                 _LOGGER.info(
                     "Adding new RF link quality sensor entity for device %s", device.id
                 )
+            if isinstance(device, Pump) and device.id not in known_pump_devices:
+                known_pump_devices.add(device.id)
+                device_entities.extend(
+                    [
+                        GardenaPumpPressureSensor(coordinator, device),
+                        GardenaPumpTemperatureSensor(coordinator, device),
+                        GardenaPumpFlowRateSensor(coordinator, device),
+                        GardenaPumpFlowTotalSensor(coordinator, device),
+                        GardenaPumpFlowSinceResetSensor(coordinator, device),
+                        GardenaPumpStateSensor(coordinator, device),
+                    ]
+                )
+                _LOGGER.info("Adding new pump sensor entities for device %s", device.id)
             if device_entities:
                 sid = find_device_subentry_id(entry, device.id)
                 entities_by_subentry_id.setdefault(sid, []).extend(device_entities)
@@ -203,3 +227,132 @@ class GardenaRfLinkQualitySensor(GardenaEntity, SensorEntity):
         if not device:
             return None
         return device.rf_link_quality
+
+
+class GardenaPumpPressureSensor(GardenaEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_outlet_pressure"
+        self._attr_name = "Outlet Pressure"
+        self._attr_device_class = SensorDeviceClass.PRESSURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfPressure.BAR
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        return device.outlet_pressure
+
+
+class GardenaPumpTemperatureSensor(GardenaEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_outlet_temperature"
+        self._attr_name = "Outlet Temperature"
+        self._attr_device_class = SensorDeviceClass.TEMPERATURE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        temp = device.outlet_temperature
+        return float(temp) if temp is not None else None
+
+
+class GardenaPumpFlowRateSensor(GardenaEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_flow_rate"
+        self._attr_name = "Flow Rate"
+        self._attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+        self._attr_native_unit_of_measurement = UnitOfVolumeFlowRate.LITERS_PER_HOUR
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        rate = device.flow_rate
+        return float(rate) if rate is not None else None
+
+
+class GardenaPumpFlowTotalSensor(GardenaEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_flow_total"
+        self._attr_name = "Total Flow"
+        self._attr_device_class = SensorDeviceClass.WATER
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        total = device.flow_total
+        return float(total) if total is not None else None
+
+
+class GardenaPumpFlowSinceResetSensor(GardenaEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_flow_since_reset"
+        self._attr_name = "Flow Since Reset"
+        self._attr_device_class = SensorDeviceClass.WATER
+        self._attr_state_class = SensorStateClass.TOTAL_INCREASING
+        self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
+
+    @property
+    def native_value(self) -> float | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        flow = device.flow_since_last_reset
+        return float(flow) if flow is not None else None
+
+
+class GardenaPumpStateSensor(GardenaEntity, SensorEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_pump_state"
+        self._attr_name = "Pump State"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    @property
+    def native_value(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        state = device.pump_state
+        return str(state) if state is not None else None

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -14,7 +14,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices import PowerAdapter
+from gardena_smart_local_api.devices import PowerAdapter, Pump
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -43,6 +43,13 @@ async def async_setup_entry(
                     GardenaPowerSwitch(coordinator, device)
                 )
                 _LOGGER.info("Adding new switch entity for device %s", device.id)
+            elif isinstance(device, Pump) and device.id not in known_devices:
+                known_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPumpSwitch(coordinator, device)
+                )
+                _LOGGER.info("Adding new pump switch entity for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -80,3 +87,35 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
             self._device.build_disable_output_obj(),
         )
         _LOGGER.info("Turning off switch %s", self._device.id)
+
+
+class GardenaPumpSwitch(GardenaEntity, SwitchEntity):
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_switch"
+        self._attr_name = None
+
+    @property
+    def is_on(self) -> bool | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        return device.is_running
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_start_obj(DEFAULT_ON_DURATION_SECONDS),
+        )
+        _LOGGER.info("Turning on pump %s", self._device.id)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_stop_obj(),
+        )
+        _LOGGER.info("Turning off pump %s", self._device.id)


### PR DESCRIPTION
Adds support for the GARDENA pump device (model 22538).

### Entities added

- **Switch**: on/off via `start`/`stop`
- **Sensors**: outlet pressure, outlet temperature, flow rate, total flow, flow since reset, pump state
- **Select**: operating mode (scheduled / automatic)
- **Numbers**: turn-on pressure, dripping alert timeout
- **Buttons**: reset resettable flow, reset valve errors, reset temperature min/max