### PR TITLE
Adapt valve entity to gardena-smart-local-api 0.0.7

### DIFF
--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
-  "requirements": ["gardena-smart-local-api==0.0.6"],
+  "requirements": ["gardena-smart-local-api==0.0.7"],
   "version": "0.0.2",
   "zeroconf": ["_gardena-smart._tcp.local."]
 }

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -58,8 +58,8 @@ class GardenaValve(GardenaEntity, ValveEntity):
         device = self.coordinator.data.get(self._device.id)
         if not device:
             return None
-        watering_timer = device.watering_timer
-        is_opened = device.is_opened
+        watering_timer = device.get_watering_timer(0)
+        is_opened = device.is_valve_open(0)
         _LOGGER.debug(
             "Valve %s watering_timer=%s, is_opened=%s, returning is_closed=%s",
             self._device.id,
@@ -67,18 +67,20 @@ class GardenaValve(GardenaEntity, ValveEntity):
             is_opened,
             not is_opened,
         )
+        if is_opened is None:
+            return None
         return not is_opened
 
     async def async_open_valve(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_set_watering_timer_obj(1800),
+            self._device.build_open_valve_obj(0, 1800),
         )
         _LOGGER.info("Opening valve %s", self._device.id)
 
     async def async_close_valve(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_stop_watering_obj(),
+            self._device.build_close_valve_obj(0),
         )
         _LOGGER.info("Closing valve %s", self._device.id)


### PR DESCRIPTION
## Summary
- Update `Gen1WaterControl` valve operations to lib 0.0.7 API
- Replace `watering_timer` property with `get_watering_timer(0)` and `is_opened` with `is_valve_open(0)`
- Replace `build_set_watering_timer_obj`/`build_stop_watering_obj` with `build_open_valve_obj(0, ...)`/`build_close_valve_obj(0)`
- Add `None` guard on `is_valve_open` so `is_closed` correctly returns `None` when state is unknown

## Test plan
- [ ] Deploy to test HA instance and verify valve entity appears without errors
- [ ] Open and close valve via HA UI, confirm state updates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)