### PR TITLE
Add device inclusion via ConfigSubentryFlow

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -2,7 +2,11 @@ import logging
 
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigEntry, SOURCE_IMPORT
+
+from homeassistant.config_entries import (
+    ConfigEntry,
+    SOURCE_IMPORT,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.const import (
     CONF_HOST,

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -5,11 +5,14 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigEntryChange,
     ConfigSubentry,
+    SIGNAL_CONFIG_ENTRY_CHANGED,
     SOURCE_IMPORT,
 )
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -140,6 +143,37 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await coordinator.async_disconnect()
 
     entry.async_on_unload(hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, _stop))
+
+    known_subentries: dict[str, str] = {
+        sid: se.data["device_id"]
+        for sid, se in entry.subentries.items()
+        if "device_id" in se.data
+    }
+
+    @callback
+    def _on_entry_updated(
+        change_type: ConfigEntryChange, changed_entry: ConfigEntry
+    ) -> None:
+        if (
+            change_type != ConfigEntryChange.UPDATED
+            or changed_entry.entry_id != entry.entry_id
+        ):
+            return
+        current_ids = set(entry.subentries.keys())
+        for subentry_id, device_id in list(known_subentries.items()):
+            if subentry_id not in current_ids:
+                del known_subentries[subentry_id]
+                hass.async_create_background_task(
+                    coordinator.async_exclude_device(device_id),
+                    f"gardena_exclude_{device_id}",
+                )
+        for sid, se in entry.subentries.items():
+            if sid not in known_subentries and "device_id" in se.data:
+                known_subentries[sid] = se.data["device_id"]
+
+    entry.async_on_unload(
+        async_dispatcher_connect(hass, SIGNAL_CONFIG_ENTRY_CHANGED, _on_entry_updated)
+    )
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     return True

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -5,9 +5,11 @@ import voluptuous as vol
 
 from homeassistant.config_entries import (
     ConfigEntry,
+    ConfigSubentry,
     SOURCE_IMPORT,
 )
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry as dr
 from homeassistant.const import (
     CONF_HOST,
     CONF_PORT,
@@ -67,8 +69,63 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+# TODO remove this migration code after a few releases, once we can be sure most users have migrated to the new config entries structure with subentries
+def _async_migrate_devices_to_subentries(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    dev_reg = dr.async_get(hass)
+    for dev_entry in dr.async_entries_for_config_entry(dev_reg, entry.entry_id):
+        if None not in dev_entry.config_entries_subentries[entry.entry_id]:
+            continue
+
+        device_id = next(
+            (id_ for domain, id_ in dev_entry.identifiers if domain == DOMAIN),
+            None,
+        )
+        if device_id is None:
+            _LOGGER.warning(
+                "Device %s linked to entry without %s identifier; skipping",
+                dev_entry.id,
+                DOMAIN,
+            )
+            continue
+
+        subentry = next(
+            (
+                se
+                for se in entry.subentries.values()
+                if se.data.get("device_id") == device_id
+            ),
+            None,
+        )
+        if subentry is None:
+            title = (
+                f"{dev_entry.model} {dev_entry.serial_number}"
+                if dev_entry.model and dev_entry.serial_number
+                else device_id
+            )
+            subentry = ConfigSubentry(
+                data={"device_id": device_id},
+                subentry_type="device",
+                title=title,
+                unique_id=device_id,
+            )
+            hass.config_entries.async_add_subentry(entry, subentry)
+
+        dev_reg.async_update_device(
+            dev_entry.id,
+            add_config_entry_id=entry.entry_id,
+            add_config_subentry_id=subentry.subentry_id,
+            remove_config_entry_id=entry.entry_id,
+            remove_config_subentry_id=None,
+        )
+        _LOGGER.info("Migrated device %s to subentry", device_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     hass.data.setdefault(DOMAIN, {})
+
+    _async_migrate_devices_to_subentries(hass, entry)
 
     coordinator = GardenaSmartLocalCoordinator(
         hass,

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -29,6 +29,7 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        known_frost_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if (

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -8,11 +8,11 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -21,7 +21,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_frost_devices: set[str] = set()
@@ -29,19 +29,22 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if (
                 hasattr(device, "has_frost_warning")
                 and device.id not in known_frost_devices
             ):
                 known_frost_devices.add(device.id)
-                new_entities.append(GardenaFrostWarningSensor(coordinator, device))
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaFrostWarningSensor(coordinator, device)
+                )
                 _LOGGER.info(
                     "Adding new frost warning sensor entity for device %s", device.id
                 )
-        if new_entities:
-            async_add_entities(new_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -6,11 +6,11 @@ from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_devices: set[str] = set()
@@ -27,14 +27,17 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if hasattr(device, "build_identify_obj") and device.id not in known_devices:
                 known_devices.add(device.id)
-                new_entities.append(GardenaIdentifyButton(coordinator, device))
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaIdentifyButton(coordinator, device)
+                )
                 _LOGGER.info("Adding identify button for device %s", device.id)
-        if new_entities:
-            async_add_entities(new_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        known_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if hasattr(device, "build_identify_obj") and device.id not in known_devices:

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -4,19 +4,34 @@ import logging
 import aiohttp
 import voluptuous as vol
 
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import (
+    ConfigEntry,
+    ConfigFlow,
+    ConfigFlowResult,
+    ConfigSubentryFlow,
+    SubentryFlowResult,
+)
+from homeassistant.core import callback
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.ssl import get_default_no_verify_context
 
 from .const import DEFAULT_PORT, DOMAIN
+from .coordinator import GardenaSmartLocalCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
 
 class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
+
+    @classmethod
+    @callback
+    def async_get_supported_subentry_types(
+        cls, config_entry: ConfigEntry
+    ) -> dict[str, type[ConfigSubentryFlow]]:
+        return {"device": GardenaInclusionSubentryFlow}
 
     def __init__(self) -> None:
         self._discovered_host: str | None = None
@@ -170,3 +185,54 @@ async def _async_try_connect(host: str, port: int, password: str) -> str | None:
         return "unknown"
 
     return None
+
+
+class GardenaInclusionSubentryFlow(ConfigSubentryFlow):
+    async def async_step_user(
+        self, user_input: dict | None = None
+    ) -> SubentryFlowResult:
+        if user_input is not None:
+            return await self.async_step_select()
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema({}),
+            last_step=False,
+        )
+
+    async def async_step_select(
+        self, user_input: dict | None = None
+    ) -> SubentryFlowResult:
+        entry = self._get_entry()
+        coordinator: GardenaSmartLocalCoordinator = self.hass.data[DOMAIN][
+            entry.entry_id
+        ]
+        devices = {k: v.device_name for k, v in coordinator.includable_devices.items()}
+
+        if not devices:
+            return self.async_abort(reason="no_devices_found")
+
+        errors: dict[str, str] = {}
+
+        if user_input is not None:
+            instance_id = user_input["device"]
+            device_id = await coordinator.async_include_device(instance_id)
+            if device_id is not None:
+                result = self.async_create_entry(
+                    title=devices[instance_id],
+                    data={"device_id": device_id},
+                    unique_id=device_id,
+                )
+                # Broadcast coordinator update after _async_finish_flow adds the
+                # subentry to entry.subentries, so _add_new_devices sees it.
+                self.hass.loop.call_soon(
+                    coordinator.async_set_updated_data, coordinator.data
+                )
+                return result
+            errors["base"] = "inclusion_failed"
+
+        return self.async_show_form(
+            step_id="select",
+            data_schema=vol.Schema({vol.Required("device"): vol.In(devices)}),
+            errors=errors,
+        )

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -1,6 +1,8 @@
 import asyncio
 import base64
 import logging
+from dataclasses import dataclass
+
 import aiohttp
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
@@ -10,6 +12,7 @@ from gardena_smart_local_api.devices import (
     Device,
     DeviceMap,
     build_discovery_obj,
+    build_inclusion_obj,
     create_devices_from_messages,
 )
 from gardena_smart_local_api.messages import (
@@ -18,6 +21,19 @@ from gardena_smart_local_api.messages import (
     EgressMessageList,
     IngressMessageList,
 )
+from gardena_smart_local_api.sgtin96 import parse_sgtin96
+
+INCLUDE_REPLY_TIMEOUT = 10
+INCLUDABLE_DEVICE_HEARTBEAT_TIMEOUT = 25
+INCLUSION_TIMEOUT = 20
+
+
+@dataclass
+class IncludableDeviceInfo:
+    instance_id: str
+    service: str
+    device_name: str
+
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -50,6 +66,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self._ssl_context = None
         self._msg_queue: asyncio.Queue[str] = asyncio.Queue()
         self._pending_replies: dict[str, asyncio.Future[Reply]] = {}
+        self._includable_devices: dict[str, IncludableDeviceInfo] = {}
+        self._includable_timeouts: dict[str, asyncio.TimerHandle] = {}
 
     async def _async_update_data(self) -> DeviceMap:
         return self._devices
@@ -62,6 +80,9 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         )
 
     async def async_disconnect(self) -> None:
+        for handle in self._includable_timeouts.values():
+            handle.cancel()
+        self._includable_timeouts.clear()
         if self._task:
             self._task.cancel()
             try:
@@ -154,7 +175,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             if passthrough:
                 await self._handle_messages(passthrough)
 
-    async def _do_discovery(self) -> None:
+    async def _do_discovery(self, broadcast: bool = True) -> None:
         discovery = build_discovery_obj()
         n = len(list(discovery))
         _LOGGER.debug("Sent discovery request, awaiting %d replies", n)
@@ -170,7 +191,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
         devices = await create_devices_from_messages(replies)
         self._update_devices(devices)
-        self.async_set_updated_data(self._devices)
+        if broadcast:
+            self.async_set_updated_data(self._devices)
         _LOGGER.info("Discovery complete, found %d device(s)", len(self._devices))
 
     async def _handle_messages(self, messages: IngressMessageList) -> None:
@@ -181,7 +203,9 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
             for msg in messages:
                 if isinstance(msg, Event):
-                    if msg.entity.device:
+                    if msg.entity.path.object_name == "includable_device":
+                        await self._handle_includable_event(msg)
+                    elif msg.entity.device:
                         device_id = msg.entity.device
                         if device_id in self._devices:
                             _LOGGER.debug(
@@ -201,6 +225,112 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
         except Exception as err:
             _LOGGER.warning("Error handling messages (may be non-critical): %s", err)
+
+    def _expire_includable(self, instance_id: str) -> None:
+        _LOGGER.debug("Includable device %s heartbeat timed out, removing", instance_id)
+        self._includable_devices.pop(instance_id, None)
+        self._includable_timeouts.pop(instance_id, None)
+
+    async def _handle_includable_event(self, event: Event) -> None:
+        instance_id = event.entity.path.object_instance_id
+        if instance_id is None:
+            return
+
+        if event.op == "delete":
+            handle = self._includable_timeouts.pop(instance_id, None)
+            if handle is not None:
+                handle.cancel()
+            self._includable_devices.pop(instance_id, None)
+            _LOGGER.debug("Includable device %s removed (delete event)", instance_id)
+            return
+
+        # Reschedule heartbeat timeout on every update
+        handle = self._includable_timeouts.pop(instance_id, None)
+        if handle is not None:
+            handle.cancel()
+        self._includable_timeouts[instance_id] = self.hass.loop.call_later(
+            INCLUDABLE_DEVICE_HEARTBEAT_TIMEOUT, self._expire_includable, instance_id
+        )
+
+        if instance_id in self._includable_devices:
+            _LOGGER.debug(
+                "Includable device %s heartbeat, rescheduled timeout", instance_id
+            )
+            return
+
+        service = event.entity.service
+        if service is None:
+            return
+
+        identifier = event.payload.get("identifier", {}).get("vs", instance_id)
+        try:
+            sgtin = parse_sgtin96(identifier)
+            device_name = f"{await sgtin.get_model_name()} {sgtin.serial:08d}"
+        except ValueError:
+            device_name = identifier
+
+        self._includable_devices[instance_id] = IncludableDeviceInfo(
+            instance_id=instance_id,
+            service=service,
+            device_name=device_name,
+        )
+        _LOGGER.info("Discovered includable device: %s (%s)", instance_id, device_name)
+
+    @property
+    def includable_devices(self) -> dict[str, IncludableDeviceInfo]:
+        return dict(self._includable_devices)
+
+    async def async_include_device(self, instance_id: str) -> str | None:
+        info = self._includable_devices.get(instance_id)
+        if info is None:
+            _LOGGER.error("No includable device with instance_id %s", instance_id)
+            return None
+
+        request = build_inclusion_obj(info.service, instance_id)
+        try:
+            replies = await self.send_request(
+                instance_id, request, wait_for_response_sec=INCLUDE_REPLY_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout waiting for inclusion reply for %s", instance_id)
+            return None
+        except Exception as err:
+            _LOGGER.error("Error including device %s: %s", instance_id, err)
+            return None
+
+        for msg in replies:
+            if isinstance(msg, Reply) and msg.success:
+                for _ in range(INCLUSION_TIMEOUT):
+                    if instance_id not in self._includable_devices:
+                        break
+                    await asyncio.sleep(1)
+                else:
+                    _LOGGER.error(
+                        "Timeout waiting for inclusion to complete for %s", instance_id
+                    )
+                    return None
+                _LOGGER.info("Device %s included successfully", instance_id)
+                known_ids = set(self._devices.keys())
+                try:
+                    # broadcast=False: the subentry doesn't exist yet at this
+                    # point; the caller schedules async_set_updated_data as a
+                    # task so it runs after _async_finish_flow adds the subentry.
+                    await self._do_discovery(broadcast=False)
+                except Exception as err:
+                    _LOGGER.warning("Re-discovery after inclusion failed: %s", err)
+                    return None
+                new_ids = set(self._devices.keys()) - known_ids
+                if not new_ids:
+                    _LOGGER.warning(
+                        "Included device %s not found in discovery", instance_id
+                    )
+                    return None
+                device_id = next(iter(new_ids))
+                _LOGGER.info("Included device_id: %s", device_id)
+                return device_id
+
+        _LOGGER.error("Inclusion of device %s failed", instance_id)
+        return None
 
     def _update_device(self, device: Device) -> None:
         is_new = device.id not in self._devices

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -4,7 +4,7 @@ import logging
 from dataclasses import dataclass
 
 import aiohttp
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
 
@@ -21,9 +21,10 @@ from gardena_smart_local_api.messages import (
     EgressMessageList,
     IngressMessageList,
 )
-from gardena_smart_local_api.sgtin96 import parse_sgtin96
+from gardena_smart_local_api.sgtin96 import SGTIN96Info
 
 INCLUDE_REPLY_TIMEOUT = 10
+EXCLUDE_REPLY_TIMEOUT = 10
 INCLUDABLE_DEVICE_HEARTBEAT_TIMEOUT = 25
 INCLUSION_TIMEOUT = 20
 
@@ -32,6 +33,7 @@ INCLUSION_TIMEOUT = 20
 class IncludableDeviceInfo:
     instance_id: str
     service: str
+    device_id: str
     device_name: str
 
 
@@ -207,7 +209,14 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                         await self._handle_includable_event(msg)
                     elif msg.entity.device:
                         device_id = msg.entity.device
-                        if device_id in self._devices:
+                        if (
+                            msg.op == "delete"
+                            and msg.entity.path.object_name is None
+                            and device_id in self._devices
+                        ):
+                            _LOGGER.info("Device %s removed (delete event)", device_id)
+                            self.async_drop_device(device_id)
+                        elif device_id in self._devices:
                             _LOGGER.debug(
                                 "Updating device %s with event: %s",
                                 device_id,
@@ -262,19 +271,35 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         if service is None:
             return
 
-        identifier = event.payload.get("identifier", {}).get("vs", instance_id)
+        identifier = event.payload.get("identifier", {}).get("vs")
+        if identifier is None:
+            _LOGGER.debug(
+                "Includable event for %s lacks identifier, ignoring", instance_id
+            )
+            return
         try:
-            sgtin = parse_sgtin96(identifier)
-            device_name = f"{await sgtin.get_model_name()} {sgtin.serial:08d}"
+            sgtin = SGTIN96Info.from_hex(identifier)
         except ValueError:
-            device_name = identifier
+            _LOGGER.debug(
+                "Includable device %s has unparseable identifier %s, ignoring",
+                instance_id,
+                identifier,
+            )
+            return
+        device_name = f"{await sgtin.get_model_name()} {sgtin.serial:08d}"
 
         self._includable_devices[instance_id] = IncludableDeviceInfo(
             instance_id=instance_id,
             service=service,
+            device_id=identifier,
             device_name=device_name,
         )
-        _LOGGER.info("Discovered includable device: %s (%s)", instance_id, device_name)
+        _LOGGER.info(
+            "Discovered includable device: %s (%s, instance %s)",
+            identifier,
+            device_name,
+            instance_id,
+        )
 
     @property
     def includable_devices(self) -> dict[str, IncludableDeviceInfo]:
@@ -285,6 +310,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         if info is None:
             _LOGGER.error("No includable device with instance_id %s", instance_id)
             return None
+        device_id = info.device_id
 
         request = build_inclusion_obj(info.service, instance_id)
         try:
@@ -292,7 +318,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 instance_id, request, wait_for_response_sec=INCLUDE_REPLY_TIMEOUT
             )
         except asyncio.TimeoutError:
-            _LOGGER.error("Timeout waiting for inclusion reply for %s", instance_id)
+            _LOGGER.error("Timeout waiting for inclusion reply for %s", device_id)
             return None
         except Exception as err:
             _LOGGER.error("Error including device %s: %s", instance_id, err)
@@ -306,11 +332,14 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     await asyncio.sleep(1)
                 else:
                     _LOGGER.error(
-                        "Timeout waiting for inclusion to complete for %s", instance_id
+                        "Timeout waiting for inclusion to complete for %s", device_id
                     )
                     return None
-                _LOGGER.info("Device %s included successfully", instance_id)
-                known_ids = set(self._devices.keys())
+                _LOGGER.info(
+                    "Device %s (instance %s) included successfully",
+                    info.device_id,
+                    instance_id,
+                )
                 try:
                     # broadcast=False: the subentry doesn't exist yet at this
                     # point; the caller schedules async_set_updated_data as a
@@ -319,18 +348,51 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 except Exception as err:
                     _LOGGER.warning("Re-discovery after inclusion failed: %s", err)
                     return None
-                new_ids = set(self._devices.keys()) - known_ids
-                if not new_ids:
+                if info.device_id not in self._devices:
                     _LOGGER.warning(
-                        "Included device %s not found in discovery", instance_id
+                        "Included device %s not found in discovery", info.device_id
                     )
                     return None
-                device_id = next(iter(new_ids))
-                _LOGGER.info("Included device_id: %s", device_id)
-                return device_id
+                return info.device_id
 
-        _LOGGER.error("Inclusion of device %s failed", instance_id)
+        _LOGGER.error("Inclusion of device %s failed", info.device_id)
         return None
+
+    @callback
+    def async_drop_device(self, device_id: str) -> None:
+        if self._devices.pop(device_id, None) is not None:
+            _LOGGER.debug("Dropped device %s from coordinator", device_id)
+            self.async_set_updated_data(self._devices)
+
+    async def async_exclude_device(self, device_id: str) -> bool:
+        device = self._devices.get(device_id)
+        if device is None:
+            _LOGGER.error("No device with id %s", device_id)
+            return False
+
+        request = device.build_exclusion_obj()
+        # Drop the device locally before requesting exclusion so the inbound
+        # delete event during factory reset cannot resurrect it via
+        # downstream listeners (e.g. subentry auto-creation).
+        self.async_drop_device(device_id)
+        try:
+            replies = await self.send_request(
+                device_id, request, wait_for_response_sec=EXCLUDE_REPLY_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.error("Timeout waiting for exclusion reply for %s", device_id)
+            return False
+        except Exception as err:
+            _LOGGER.error("Error excluding device %s: %s", device_id, err)
+            return False
+
+        for msg in replies:
+            if isinstance(msg, Reply) and msg.success:
+                _LOGGER.info("Device %s excluded successfully", device_id)
+                return True
+
+        _LOGGER.error("Exclusion of device %s failed", device_id)
+        return False
 
     def _update_device(self, device: Device) -> None:
         is_new = device.id not in self._devices

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -1,11 +1,23 @@
 from __future__ import annotations
 
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from gardena_smart_local_api.devices.device import Device
+
+
+def find_device_subentry_id(entry: ConfigEntry, device_id: str) -> str | None:
+    return next(
+        (
+            sid
+            for sid, se in entry.subentries.items()
+            if se.data.get("device_id") == device_id
+        ),
+        None,
+    )
 
 
 class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -33,6 +33,7 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        known_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if (

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -13,11 +13,11 @@ from homeassistant.components.lawn_mower import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_devices: set[str] = set()
@@ -33,17 +33,20 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if (
                 hasattr(device, "build_start_mowing_obj")
                 and device.id not in known_devices
             ):
                 known_devices.add(device.id)
-                new_entities.append(GardenaMower(coordinator, device))
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaMower(coordinator, device)
+                )
                 _LOGGER.info("Adding new mower entity for device %s", device.id)
-        if new_entities:
-            async_add_entities(new_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -6,11 +6,11 @@ from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_devices: set[str] = set()
@@ -27,19 +27,22 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if (
                 hasattr(device, "build_set_button_config_time_obj")
                 and device.id not in known_devices
             ):
                 known_devices.add(device.id)
-                new_entities.append(GardenaButtonConfigTime(coordinator, device))
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaButtonConfigTime(coordinator, device)
+                )
                 _LOGGER.info(
                     "Adding new button config time entity for device %s", device.id
                 )
-        if new_entities:
-            async_add_entities(new_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        known_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if (

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -35,6 +35,14 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        for cache in (
+            known_temp_devices,
+            known_moisture_devices,
+            known_light_devices,
+            known_battery_devices,
+            known_rf_link_devices,
+        ):
+            cache.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             device_entities = []

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -10,11 +10,11 @@ from homeassistant.components.sensor import (
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import LIGHT_LUX, PERCENTAGE, EntityCategory, UnitOfTemperature
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -23,7 +23,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_temp_devices: set[str] = set()
@@ -35,11 +35,12 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
+            device_entities = []
             if hasattr(device, "temperature") and device.id not in known_temp_devices:
                 known_temp_devices.add(device.id)
-                new_entities.append(GardenaTemperatureSensor(coordinator, device))
+                device_entities.append(GardenaTemperatureSensor(coordinator, device))
                 _LOGGER.info(
                     "Adding new temperature sensor entity for device %s", device.id
                 )
@@ -48,20 +49,20 @@ async def async_setup_entry(
                 and device.id not in known_moisture_devices
             ):
                 known_moisture_devices.add(device.id)
-                new_entities.append(GardenaSoilMoistureSensor(coordinator, device))
+                device_entities.append(GardenaSoilMoistureSensor(coordinator, device))
                 _LOGGER.info(
                     "Adding new soil moisture sensor entity for device %s", device.id
                 )
             if hasattr(device, "light") and device.id not in known_light_devices:
                 known_light_devices.add(device.id)
-                new_entities.append(GardenaLightSensor(coordinator, device))
+                device_entities.append(GardenaLightSensor(coordinator, device))
                 _LOGGER.info("Adding new light sensor entity for device %s", device.id)
             if (
                 hasattr(device, "battery_level")
                 and device.id not in known_battery_devices
             ):
                 known_battery_devices.add(device.id)
-                new_entities.append(GardenaBatterySensor(coordinator, device))
+                device_entities.append(GardenaBatterySensor(coordinator, device))
                 _LOGGER.info(
                     "Adding new battery sensor entity for device %s", device.id
                 )
@@ -70,12 +71,15 @@ async def async_setup_entry(
                 and device.id not in known_rf_link_devices
             ):
                 known_rf_link_devices.add(device.id)
-                new_entities.append(GardenaRfLinkQualitySensor(coordinator, device))
+                device_entities.append(GardenaRfLinkQualitySensor(coordinator, device))
                 _LOGGER.info(
                     "Adding new RF link quality sensor entity for device %s", device.id
                 )
-        if new_entities:
-            async_add_entities(new_entities)
+            if device_entities:
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).extend(device_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -30,6 +30,7 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        known_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if isinstance(device, PowerAdapter) and device.id not in known_devices:

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -6,11 +6,11 @@ from typing import Any
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import PowerAdapter
 
 _LOGGER = logging.getLogger(__name__)
@@ -22,7 +22,7 @@ DEFAULT_ON_DURATION_SECONDS = 16777216
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_devices: set[str] = set()
@@ -30,14 +30,17 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if isinstance(device, PowerAdapter) and device.id not in known_devices:
                 known_devices.add(device.id)
-                new_entities.append(GardenaPowerSwitch(coordinator, device))
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPowerSwitch(coordinator, device)
+                )
                 _LOGGER.info("Adding new switch entity for device %s", device.id)
-        if new_entities:
-            async_add_entities(new_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -1,4 +1,30 @@
 {
+  "config_subentries": {
+    "device": {
+      "entry_type": "Gerät",
+      "initiate_flow": {
+        "user": "Gerät einbinden"
+      },
+      "step": {
+        "user": {
+          "title": "GARDENA-Gerät einbinden",
+          "description": "Versetze dein Gerät in den Einbindungsmodus (sieh bei Bedarf in der Anleitung deines Geräts nach) und klicke dann auf **Weiter**.\n\n**Hinweis:** Hier eingebundene Geräte werden lokal mit dem Gateway gekoppelt und erscheinen nicht in der GARDENA-App. Um die App zu verwenden, binde das Gerät stattdessen über die App ein."
+        },
+        "select": {
+          "title": "Gerät zum Einbinden auswählen",
+          "data": {
+            "device": "Gerät"
+          }
+        }
+      },
+      "abort": {
+        "no_devices_found": "Keine einbindbaren Geräte gefunden. Stelle sicher, dass dein Gerät im Einbindungsmodus ist, und versuche es erneut."
+      },
+      "error": {
+        "inclusion_failed": "Gerät konnte nicht eingebunden werden. Bitte versuche es erneut."
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -1,4 +1,30 @@
 {
+  "config_subentries": {
+    "device": {
+      "entry_type": "Device",
+      "initiate_flow": {
+        "user": "Include a device"
+      },
+      "step": {
+        "user": {
+          "title": "Include a GARDENA device",
+          "description": "Put your device into inclusion mode (refer to your device's manual if unsure how), then click **Next**.\n\n**Note:** Devices included here are paired locally with the gateway and will not show up in the GARDENA app. If you wish to continue to use the app, include the device through the GARDENA app instead."
+        },
+        "select": {
+          "title": "Select a device to include",
+          "data": {
+            "device": "Device"
+          }
+        }
+      },
+      "abort": {
+        "no_devices_found": "No includable devices found. Make sure your device is in inclusion mode and try again."
+      },
+      "error": {
+        "inclusion_failed": "Failed to include the device. Please try again."
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -6,11 +6,11 @@ from typing import Any
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity
+from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import Device
 
 _LOGGER = logging.getLogger(__name__)
@@ -19,7 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,
-    async_add_entities: AddEntitiesCallback,
+    async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
     known_devices: set[str] = set()
@@ -27,19 +27,22 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
-        new_entities = []
+        entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if device.id not in known_devices and hasattr(device, "valve_ids"):
                 known_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
                 for valve_id in device.valve_ids:
-                    new_entities.append(GardenaValve(coordinator, device, valve_id))
+                    entities_by_subentry_id.setdefault(sid, []).append(
+                        GardenaValve(coordinator, device, valve_id)
+                    )
                     _LOGGER.info(
                         "Adding new valve entity for device %s, valve %s",
                         device.id,
                         valve_id,
                     )
-        if new_entities:
-            async_add_entities(new_entities)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
 
     coordinator.async_add_listener(_add_new_devices)
 

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -27,6 +27,7 @@ async def async_setup_entry(
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
+        known_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if device.id not in known_devices and hasattr(device, "valve_ids"):


### PR DESCRIPTION
## Summary

- Adds device inclusion flow via HA `ConfigSubentryFlow`, accessible from the integration page with an "Include a device" button
- Scans for devices in inclusion mode, lets the user pick one, and shows a success message with the device name

## Cases

### 1. Happy path — include a known device
- [x] Put a device in inclusion mode
- [x] *Add device* (subentry) → *Next* → select device → *Submit*
- [x] **Expect:** success message, device + entities appear under new subentry

### 2. Exclude an online device
- [x] Delete a device subentry from the UI
- [x] **Expect:** subentry + device + entities removed

### 3. Exclude an offline device **(out-of-scope for now)**
- [ ] Power off a device, wait until entities show `unavailable`
- [ ] Delete its subentry
- [ ] **Expect:** subentry + device removed from HA. (gateway cannot reach device — local removal still succeeds)
- [ ] Power device back on → confirm it does **not** auto-rejoin

### 4. Inclusion with no devices nearby
- [x] No device in inclusion mode
- [x] *Add device* → *Next*
- [x] **Expect:** abort screen *"No includable devices found. Make sure your device is in inclusion mode and try again."*

### 5. Inclusion mode timeout before submit
- [x] Device in inclusion mode → flow shows device in list
- [x] Wait > 3 minutes without submitting (device led starts flashing red)
- [x] Submit
- [x] **Expect:** form re-shown with error *"Failed to include the device. Please try again."*

### 6. Device dies during inclusion
- [x] Device in inclusion mode → open flow → device visible
- [x] Cut power to device, then submit
- [x] **Expect:** ~10 s wait, then *"Failed to include the device. Please try again."* error is shown, log shows inclusion timeout

### 7. Re-include after exclusion
- [x] Exclude a device (case 2), then put same device back in inclusion mode
- [x] Run case 1 against it
- [x] **Expect:** subentry recreated, entities restored

### 8. Cancel mid-flow
- [x] Open inclusion flow → close dialog with X
- [x] **Expect:** no subentry created, no errors

### 9. HA restart with existing subentries
- [x] After at least one successful inclusion, restart HA
- [x] **Expect:** all devices reappear under their subentries; no duplicate subentries; no migration log lines

### 10. Migration from pre-subentry version
- [x] Set up integration on `main` (devices created without subentries)
- [x] Update to this branch, restart HA
- [x] **Expect:** one `Migrated device <id> to subentry` line per device; each device now under its own subentry; single restart sufficient

### 11. Gateway unreachable during exclusion
- [x] Block gateway (firewall / unplug) → delete a subentry
- [x] **Expect:** exclusion fails in log, device still removed from HA locally


## Screenshots

<img width="1920" height="993" alt="screenshot_1_integration_page" src="https://github.com/user-attachments/assets/54c4bcfa-2e7f-4c9d-9510-40c61c3f9cd8" />


<img width="2560" height="961" alt="screenshot_2_include_dialog" src="https://github.com/user-attachments/assets/eab8529e-3553-4d9a-b537-3bfb4ab07816" />

<img width="2560" height="961" alt="screenshot_3_after_submit" src="https://github.com/user-attachments/assets/0098da7f-75dc-42f6-956a-0d09ab792e68" />

<img width="2560" height="961" alt="screenshot_4_success" src="https://github.com/user-attachments/assets/fc8b4c1d-03e6-483d-9329-04e3f6ffa680" />

above screenshots are not from the latest version, but the flow is the same
latest version uses subentries for the devices, this allows to delete (and exclude) devices

<img width="1027" height="735" alt="image" src="https://github.com/user-attachments/assets/e11d2f0b-3f04-4b79-8dff-d8e44d450735" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)