### PR TITLE
Add Playwright and screenshot artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 # OS
 .DS_Store
 
+# Playwright
+.playwright*/
+screenshot*.png
+
 # Python
 *.pyc
 .ruff_cache/


### PR DESCRIPTION
I'm using the playwright mcp for exploring/debugging, want to prevent accidentally committing these files :)