### PR TITLE
Use ConfigEntry.runtime_data instead of hass.data

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -56,8 +56,6 @@ CONFIG_SCHEMA = vol.Schema(
 
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
-    hass.data.setdefault(DOMAIN, {})
-
     if DOMAIN not in config:
         return True
 
@@ -130,8 +128,6 @@ def _async_migrate_devices_to_subentries(
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    hass.data.setdefault(DOMAIN, {})
-
     _async_migrate_devices_to_subentries(hass, entry)
 
     coordinator = GardenaSmartLocalCoordinator(
@@ -141,7 +137,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         password=entry.data[CONF_PASSWORD],
     )
     await coordinator.async_connect()
-    hass.data[DOMAIN][entry.entry_id] = coordinator
+    entry.runtime_data = coordinator
 
     async def _stop(_event: object) -> None:
         await coordinator.async_disconnect()
@@ -184,6 +180,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN].pop(entry.entry_id)
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     await coordinator.async_disconnect()
     return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -14,7 +14,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
@@ -27,7 +26,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_frost_devices: set[str] = set()
 
     def _add_new_devices() -> None:

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
@@ -25,7 +24,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
 
     def _add_new_devices() -> None:

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -19,7 +19,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 
@@ -31,7 +30,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
 
     def _add_new_devices() -> None:

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -12,7 +12,6 @@ from homeassistant.const import EntityCategory, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
@@ -25,7 +24,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
 
     def _add_new_devices() -> None:

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -16,7 +16,6 @@ from homeassistant.const import LIGHT_LUX, PERCENTAGE, EntityCategory, UnitOfTem
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
@@ -29,7 +28,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_temp_devices: set[str] = set()
     known_moisture_devices: set[str] = set()
     known_light_devices: set[str] = set()

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import PowerAdapter
@@ -28,7 +27,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
 
     def _add_new_devices() -> None:

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -12,7 +12,6 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
-from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import Device
@@ -25,7 +24,7 @@ async def async_setup_entry(
     entry: ConfigEntry,
     async_add_entities: AddConfigEntryEntitiesCallback,
 ) -> None:
-    coordinator: GardenaSmartLocalCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
 
     def _add_new_devices() -> None:


### PR DESCRIPTION
Replaces the `hass.data[DOMAIN]` dict pattern with `ConfigEntry.runtime_data` across all platform files.

Satisfies the [runtime-data](https://developers.home-assistant.io/docs/core/integration-quality-scale/rules/runtime-data) IQS Bronze rule.