### PR TITLE
Add WebSocket heartbeat to detect dead connections

### DIFF
--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -105,6 +105,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     async with session.ws_connect(
                         self.uri,
                         ssl=self._ssl_context,
+                        heartbeat=30,
                         headers={"Authorization": f"Basic {self.auth_b64}"},
                     ) as ws:
                         self._ws = ws


### PR DESCRIPTION
the integration often got into a stale state with unavailable devices, adding the heartbeat arg should detect stale websocket connection now