### PR TITLE
Add firmware update support

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -39,6 +39,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.UPDATE,
     Platform.VALVE,
 ]
 _LOGGER = logging.getLogger(__name__)

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -26,11 +26,13 @@ from gardena_smart_local_api.messages import (
     IngressMessageList,
 )
 from gardena_smart_local_api.sgtin96 import SGTIN96Info
+from gardena_smart_local_api.utils import deep_merge_dict
 
 INCLUDE_REPLY_TIMEOUT = 10
 EXCLUDE_REPLY_TIMEOUT = 10
 INCLUDABLE_DEVICE_HEARTBEAT_TIMEOUT = 25
 INCLUSION_TIMEOUT = 30
+FIRMWARE_REPLY_TIMEOUT = 10
 
 
 @dataclass
@@ -428,6 +430,36 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
         _LOGGER.error("Exclusion of device %s failed", device_id)
         return False
+
+    async def async_refresh_firmware(self, device_id: str) -> None:
+        device = self._devices.get(device_id)
+        if device is None:
+            return
+
+        request = (
+            device.build_refresh_available_firmware_version_obj()
+            + device.build_refresh_firmware_update_state_obj()
+        )
+        try:
+            replies = await self.send_request(
+                device_id, request, wait_for_response_sec=FIRMWARE_REPLY_TIMEOUT
+            )
+        except asyncio.TimeoutError:
+            _LOGGER.debug("Timeout refreshing firmware state for %s", device_id)
+            return
+        except Exception as err:
+            _LOGGER.debug("Error refreshing firmware state for %s: %s", device_id, err)
+            return
+
+        updated = False
+        for msg in replies:
+            if isinstance(msg, Reply) and msg.success and msg.payload:
+                data = msg.payload.get(device_id)
+                if data:
+                    deep_merge_dict(device.data, data)
+                    updated = True
+        if updated:
+            self.async_set_updated_data(self._devices)
 
     def _update_device(self, device: Device) -> None:
         is_new = device.id not in self._devices

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -49,3 +50,23 @@ class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):
     def available(self) -> bool:
         device = self.coordinator.data.get(self._device.id)
         return bool(device and device.is_online)
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Keep the device registry sw_version in sync.
+
+        DeviceInfo is only applied when the entity is added, so after a
+        firmware up-/downgrade the device page would keep showing the old
+        version until Home Assistant restarts.
+        """
+        device = self.coordinator.data.get(self._device.id)
+        if (
+            device
+            and device.software_version
+            and self.device_entry
+            and self.device_entry.sw_version != device.software_version
+        ):
+            dr.async_get(self.hass).async_update_device(
+                self.device_entry.id, sw_version=device.software_version
+            )
+        super()._handle_coordinator_update()

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -26,7 +26,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices.device import Device
+from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
 from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
@@ -45,6 +45,7 @@ async def async_setup_entry(
     known_rf_link_devices: set[str] = set()
     known_pump_devices: set[str] = set()
     known_schedule_devices: set[str] = set()
+    known_firmware_state_devices: set[str] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
@@ -57,6 +58,7 @@ async def async_setup_entry(
             known_rf_link_devices,
             known_pump_devices,
             known_schedule_devices,
+            known_firmware_state_devices,
         ):
             cache.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
@@ -119,6 +121,14 @@ async def async_setup_entry(
                 known_schedule_devices.add(device.id)
                 device_entities.append(GardenaScheduleCountSensor(coordinator, device))
                 _LOGGER.info("Adding schedule count sensor for device %s", device.id)
+            if device.id not in known_firmware_state_devices:
+                known_firmware_state_devices.add(device.id)
+                device_entities.append(
+                    GardenaFirmwareUpdateStateSensor(coordinator, device)
+                )
+                _LOGGER.info(
+                    "Adding firmware update state sensor for device %s", device.id
+                )
             if device_entities:
                 sid = find_device_subentry_id(entry, device.id)
                 entities_by_subentry_id.setdefault(sid, []).extend(device_entities)
@@ -389,3 +399,30 @@ class GardenaScheduleCountSensor(GardenaEntity, SensorEntity):
         if not device:
             return None
         return device.schedule_count
+
+
+class GardenaFirmwareUpdateStateSensor(GardenaEntity, SensorEntity):
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options = [str(state) for state in FirmwareUpdateState]
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Device,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_firmware_update_state"
+        self._attr_translation_key = "firmware_update_state"
+        self._attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        await self.coordinator.async_refresh_firmware(self._device.id)
+
+    @property
+    def native_value(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        state = device.firmware_update_state
+        return str(state) if state is not None else None

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -1,4 +1,17 @@
 {
+  "entity": {
+    "sensor": {
+      "firmware_update_state": {
+        "name": "Firmware-Update-Status",
+        "state": {
+          "idle": "Inaktiv",
+          "downloading": "Wird heruntergeladen",
+          "downloaded": "Heruntergeladen",
+          "updating": "Wird aktualisiert"
+        }
+      }
+    }
+  },
   "config_subentries": {
     "device": {
       "entry_type": "Gerät",

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -1,4 +1,17 @@
 {
+  "entity": {
+    "sensor": {
+      "firmware_update_state": {
+        "name": "Firmware Update State",
+        "state": {
+          "idle": "Idle",
+          "downloading": "Downloading",
+          "downloaded": "Downloaded",
+          "updating": "Updating"
+        }
+      }
+    }
+  },
   "config_subentries": {
     "device": {
       "entry_type": "Device",

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -1,0 +1,132 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
+
+from .coordinator import GardenaSmartLocalCoordinator
+from .entity import GardenaEntity, find_device_subentry_id
+from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
+
+_LOGGER = logging.getLogger(__name__)
+
+_IN_PROGRESS_STATES = (FirmwareUpdateState.UPDATING,)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddConfigEntryEntitiesCallback,
+) -> None:
+    coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
+    known_devices: set[str] = set()
+
+    def _add_new_devices() -> None:
+        if not coordinator.data:
+            return
+        known_devices.intersection_update(coordinator.data)
+        entities_by_subentry_id: dict[str | None, list] = {}
+        for device in coordinator.data.values():
+            if device.id in known_devices:
+                continue
+            known_devices.add(device.id)
+            sid = find_device_subentry_id(entry, device.id)
+            entities_by_subentry_id.setdefault(sid, []).append(
+                GardenaFirmwareUpdate(coordinator, device)
+            )
+            _LOGGER.info("Adding firmware update entity for device %s", device.id)
+        for sid, entities in entities_by_subentry_id.items():
+            async_add_entities(entities, config_subentry_id=sid)
+
+    coordinator.async_add_listener(_add_new_devices)
+
+
+class GardenaFirmwareUpdate(GardenaEntity, UpdateEntity):
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = (
+        UpdateEntityFeature.INSTALL | UpdateEntityFeature.PROGRESS
+    )
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Device,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_firmware"
+        self._held_latest_version: str | None = None
+
+    async def async_added_to_hass(self) -> None:
+        await super().async_added_to_hass()
+        await self.coordinator.async_refresh_firmware(self._device.id)
+
+    @property
+    def installed_version(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        return device.software_version if device else None
+
+    @property
+    def latest_version(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        state = device.firmware_update_state
+        if state == FirmwareUpdateState.DOWNLOADED:
+            return device.available_software_version or device.software_version
+        if state in _IN_PROGRESS_STATES:
+            return (
+                self._held_latest_version
+                or device.available_software_version
+                or device.software_version
+            )
+        # IDLE or DOWNLOADING: package not ready yet, do not offer an update
+        return device.software_version
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        """Hold the target version while an update is running.
+
+        The gateway clears or rewrites pkg_version while flashing, which
+        would make latest_version flap until the update finishes.
+        """
+        device = self.coordinator.data.get(self._device.id)
+        if device:
+            if device.firmware_update_state in _IN_PROGRESS_STATES:
+                if self._held_latest_version is None:
+                    self._held_latest_version = device.available_software_version
+            else:
+                self._held_latest_version = None
+        super()._handle_coordinator_update()
+
+    def version_is_newer(self, latest_version: str, installed_version: str) -> bool:
+        """Check if versions differ, allowing downgrades as valid updates."""
+        return latest_version != installed_version
+
+    @property
+    def in_progress(self) -> bool:
+        device = self.coordinator.data.get(self._device.id)
+        return bool(device and device.firmware_update_state in _IN_PROGRESS_STATES)
+
+    async def async_install(
+        self, version: str | None, backup: bool, **kwargs: Any
+    ) -> None:
+        device = self.coordinator.data.get(self._device.id)
+        if device:
+            self._held_latest_version = device.available_software_version
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_install_firmware_update_obj(),
+        )
+        _LOGGER.info("Sent firmware install request for device %s", self._device.id)


### PR DESCRIPTION
For testing:

set `fota_loop: true` in `/etc/fwrolloutd.yml`
and restart fwrolloutd: `systemctl restart fwrolloutd`

This implements the happy case, it does not check the update result for errors

[gardena-smart-local-api#67](https://github.com/cloudless-garden/gardena-smart-local-api/pull/67) needs to be released first