### PR TITLE
Add (disabled) schedule count and clear schedules entities to devices

### DIFF
--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -28,12 +28,14 @@ async def async_setup_entry(
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
     known_pump_devices: set[str] = set()
+    known_schedule_devices: set[str] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
         known_devices.intersection_update(coordinator.data)
         known_pump_devices.intersection_update(coordinator.data)
+        known_schedule_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if hasattr(device, "build_identify_obj") and device.id not in known_devices:
@@ -54,6 +56,16 @@ async def async_setup_entry(
                     ]
                 )
                 _LOGGER.info("Adding pump reset buttons for device %s", device.id)
+            if (
+                hasattr(device, "schedule_count")
+                and device.id not in known_schedule_devices
+            ):
+                known_schedule_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaClearSchedulesButton(coordinator, device)
+                )
+                _LOGGER.info("Adding clear schedules button for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -121,3 +133,24 @@ class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
             self._device.build_reset_outlet_temperature_min_max_obj(),
         )
         _LOGGER.info("Reset temperature min/max for device %s", self._device.id)
+
+
+class GardenaClearSchedulesButton(GardenaEntity, ButtonEntity):
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_entity_registry_enabled_default = False
+    _attr_has_entity_name = True
+    _attr_name = "Clear Schedules"
+    _attr_icon = "mdi:delete-alert-outline"
+
+    def __init__(
+        self, coordinator: GardenaSmartLocalCoordinator, device: Device
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_clear_schedules"
+
+    async def async_press(self) -> None:
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_clear_schedules_obj(),
+        )
+        _LOGGER.info("Cleared schedules for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
-  "requirements": ["gardena-smart-local-api==0.0.11"],
+  "requirements": ["gardena-smart-local-api==0.1.0"],
   "version": "0.0.7",
   "zeroconf": ["_gardena-smart._tcp.local."]
 }

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -44,6 +44,7 @@ async def async_setup_entry(
     known_battery_devices: set[str] = set()
     known_rf_link_devices: set[str] = set()
     known_pump_devices: set[str] = set()
+    known_schedule_devices: set[str] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
@@ -55,6 +56,7 @@ async def async_setup_entry(
             known_battery_devices,
             known_rf_link_devices,
             known_pump_devices,
+            known_schedule_devices,
         ):
             cache.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
@@ -110,6 +112,13 @@ async def async_setup_entry(
                     ]
                 )
                 _LOGGER.info("Adding new pump sensor entities for device %s", device.id)
+            if (
+                hasattr(device, "schedule_count")
+                and device.id not in known_schedule_devices
+            ):
+                known_schedule_devices.add(device.id)
+                device_entities.append(GardenaScheduleCountSensor(coordinator, device))
+                _LOGGER.info("Adding schedule count sensor for device %s", device.id)
             if device_entities:
                 sid = find_device_subentry_id(entry, device.id)
                 entities_by_subentry_id.setdefault(sid, []).extend(device_entities)
@@ -356,3 +365,27 @@ class GardenaPumpStateSensor(GardenaEntity, SensorEntity):
             return None
         state = device.pump_state
         return str(state) if state is not None else None
+
+
+class GardenaScheduleCountSensor(GardenaEntity, SensorEntity):
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+    _attr_has_entity_name = True
+    _attr_name = "Schedule Count"
+    _attr_icon = "mdi:calendar-check"
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Device,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_schedule_count"
+        self._attr_state_class = SensorStateClass.MEASUREMENT
+
+    @property
+    def native_value(self) -> int | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        return device.schedule_count


### PR DESCRIPTION
Provide a way to see if a device has a schedule and allow to clear it without the Gardena App, device type agnostic, lib needs to support it