### PR TITLE
Quality scale fixes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -41,8 +41,20 @@ jobs:
   tests:
     name: Tests
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v6
       - run: uv sync --group dev
-      - run: uv run pytest tests/ -v
+      - name: Run tests with coverage
+        run: >
+          uv run pytest tests/ -v
+          --cov=custom_components.gardena_smart_local_preview
+          --cov-report=term --cov-report=xml
+      - name: Coverage comment
+        if: github.event_name == 'pull_request'
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           args: format --check
 
+  ty:
+    name: ty
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --group dev
+      - run: uv run ty check custom_components
+
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,11 @@ screenshot*.png
 
 # Python
 *.pyc
+__pycache__/
 .ruff_cache/
 .venv/
+
+# Test artifacts
+.coverage
+coverage.xml
+.pytest_cache/

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -5,9 +5,11 @@
 from __future__ import annotations
 
 import logging
+from typing import Protocol, cast
 
 from gardena_smart_local_api.devices import Pump
 from gardena_smart_local_api.devices.device import Device
+from gardena_smart_local_api.messages import EgressMessageList
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
@@ -22,6 +24,14 @@ _LOGGER = logging.getLogger(__name__)
 # Actions send commands to the gateway's local websocket — cap at 1 so HA
 # serializes them instead of firing concurrent commands at the same connection
 PARALLEL_UPDATES = 1
+
+
+class _Identifiable(Protocol):
+    def build_identify_obj(self) -> EgressMessageList: ...
+
+
+class _ScheduleClearable(Protocol):
+    def build_clear_schedules_obj(self) -> EgressMessageList: ...
 
 
 async def async_setup_entry(
@@ -88,7 +98,9 @@ class GardenaIdentifyButton(GardenaEntity, ButtonEntity):
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_press(self) -> None:
-        await self._send_confirmed_command(self._device.build_identify_obj())
+        await self._send_confirmed_command(
+            cast(_Identifiable, self._device).build_identify_obj()
+        )
         _LOGGER.info("Sent identify request for device %s", self._device.id)
 
 
@@ -101,7 +113,7 @@ class GardenaPumpResetFlowButton(GardenaEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         await self._send_confirmed_command(
-            self._device.build_reset_flow_resettable_obj()
+            cast(Pump, self._device).build_reset_flow_resettable_obj()
         )
         _LOGGER.info("Reset resettable flow for device %s", self._device.id)
 
@@ -115,7 +127,7 @@ class GardenaPumpResetValveErrorsButton(GardenaEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         await self._send_confirmed_command(
-            self._device.build_reset_all_valve_errors_obj()
+            cast(Pump, self._device).build_reset_all_valve_errors_obj()
         )
         _LOGGER.info("Reset valve errors for device %s", self._device.id)
 
@@ -129,7 +141,7 @@ class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
 
     async def async_press(self) -> None:
         await self._send_confirmed_command(
-            self._device.build_reset_outlet_temperature_min_max_obj()
+            cast(Pump, self._device).build_reset_outlet_temperature_min_max_obj()
         )
         _LOGGER.info("Reset temperature min/max for device %s", self._device.id)
 
@@ -147,5 +159,7 @@ class GardenaClearSchedulesButton(GardenaEntity, ButtonEntity):
         self._attr_unique_id = f"{device.id}_clear_schedules"
 
     async def async_press(self) -> None:
-        await self._send_confirmed_command(self._device.build_clear_schedules_obj())
+        await self._send_confirmed_command(
+            cast(_ScheduleClearable, self._device).build_clear_schedules_obj()
+        )
         _LOGGER.info("Cleared schedules for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -133,6 +133,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             consumer_task = None
             try:
                 _LOGGER.debug("Connecting to GARDENA smart Gateway at %s", self.uri)
+                # Always set by async_connect() before this task starts.
+                assert self._ssl_context is not None
                 session = async_get_clientsession(self.hass)
                 async with session.ws_connect(
                     self.uri,

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -7,8 +7,15 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
-from gardena_smart_local_api.devices import Device, MowerState
+from gardena_smart_local_api.devices import (
+    Device,
+    Gen1Mower1,
+    Gen1Mower2,
+    Gen2Mower,
+    MowerState,
+)
 from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
     LawnMowerEntity,
@@ -26,6 +33,8 @@ _LOGGER = logging.getLogger(__name__)
 # Actions send commands to the gateway's local websocket — cap at 1 so HA
 # serializes them instead of firing concurrent commands at the same connection
 PARALLEL_UPDATES = 1
+
+_Mower = Gen1Mower1 | Gen1Mower2 | Gen2Mower
 
 
 async def async_setup_entry(
@@ -80,7 +89,7 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
         device = self.coordinator.data.get(self._device.id)
         if device is None:
             return None
-        mower_state = device.state
+        mower_state = cast(_Mower, device).state
         _LOGGER.debug("Mower status: %s", mower_state)
         match mower_state:
             case MowerState.CHARGING | MowerState.PARKED:
@@ -103,17 +112,21 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
 
     async def async_start_mowing(self) -> None:
         await self._send_confirmed_command(
-            self._device.build_start_mowing_obj(28800)  # 8 hours
+            cast(_Mower, self._device).build_start_mowing_obj(28800)  # 8 hours
         )
         _LOGGER.info("Start mowing with %s", self._device.id)
 
     async def async_dock(self) -> None:
-        await self._send_confirmed_command(self._device.build_stop_mowing_obj())
+        await self._send_confirmed_command(
+            cast(_Mower, self._device).build_stop_mowing_obj()
+        )
         _LOGGER.info("Stop mowing with %s", self._device.id)
 
     async def async_pause(self) -> None:
         if hasattr(self._device, "build_pause_mowing_obj"):
-            await self._send_confirmed_command(self._device.build_pause_mowing_obj())
+            await self._send_confirmed_command(
+                cast(Gen2Mower, self._device).build_pause_mowing_obj()
+            )
             _LOGGER.info("Pause mowing with %s", self._device.id)
         else:
             _LOGGER.warning("Pause not supported for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -5,8 +5,9 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
-from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices import Gen1WaterControl, Pump
 from gardena_smart_local_api.devices.device import Device
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -150,11 +151,13 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         seconds = int(value) * 60
         if hasattr(self._device, "get_button_config_time"):
-            request = self._device.build_set_button_config_time_obj(
-                seconds, self._valve_id
-            )
+            request = cast(
+                Gen1WaterControl, self._device
+            ).build_set_button_config_time_obj(seconds, self._valve_id)
         else:
-            request = self._device.build_set_button_config_time_obj(seconds)
+            request = cast(
+                Gen1WaterControl, self._device
+            ).build_set_button_config_time_obj(seconds)
         await self._send_confirmed_command(request)
         _LOGGER.info(
             "Set button config time for device %s, valve %s to %s minutes",
@@ -190,7 +193,7 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
 
     async def async_set_native_value(self, value: float) -> None:
         await self._send_confirmed_command(
-            self._device.build_set_turn_on_pressure_obj(value)
+            cast(Pump, self._device).build_set_turn_on_pressure_obj(value)
         )
         _LOGGER.info(
             "Set turn-on pressure for device %s to %s bar",

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import ClassVar
+from typing import ClassVar, cast
 
 from gardena_smart_local_api.devices import Pump
 from gardena_smart_local_api.devices.irrigation import (
@@ -99,7 +99,7 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
     async def async_select_option(self, option: str) -> None:
         mode = _OPTION_TO_MODE[option]
         await self._send_confirmed_command(
-            self._device.build_set_operating_mode_obj(mode)
+            cast(Pump, self._device).build_set_operating_mode_obj(mode)
         )
         _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)
 

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from gardena_smart_local_api.devices import PowerAdapter, Pump
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
@@ -81,12 +81,16 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self._send_confirmed_command(
-            self._device.build_enable_output_obj(DEFAULT_ON_DURATION_SECONDS)
+            cast(PowerAdapter, self._device).build_enable_output_obj(
+                DEFAULT_ON_DURATION_SECONDS
+            )
         )
         _LOGGER.info("Turning on switch %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self._send_confirmed_command(self._device.build_disable_output_obj())
+        await self._send_confirmed_command(
+            cast(PowerAdapter, self._device).build_disable_output_obj()
+        )
         _LOGGER.info("Turning off switch %s", self._device.id)
 
 
@@ -109,10 +113,10 @@ class GardenaPumpSwitch(GardenaEntity, SwitchEntity):
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self._send_confirmed_command(
-            self._device.build_start_obj(DEFAULT_ON_DURATION_SECONDS)
+            cast(Pump, self._device).build_start_obj(DEFAULT_ON_DURATION_SECONDS)
         )
         _LOGGER.info("Turning on pump %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self._send_confirmed_command(self._device.build_stop_obj())
+        await self._send_confirmed_command(cast(Pump, self._device).build_stop_obj())
         _LOGGER.info("Turning off pump %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -5,10 +5,11 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Protocol, cast
 
 import voluptuous as vol
 from gardena_smart_local_api.devices import Device
+from gardena_smart_local_api.messages import EgressMessageList
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -27,6 +28,16 @@ _LOGGER = logging.getLogger(__name__)
 # Actions send commands to the gateway's local websocket — cap at 1 so HA
 # serializes them instead of firing concurrent commands at the same connection
 PARALLEL_UPDATES = 1
+
+
+class _ValveCapableDevice(Protocol):
+    valve_ids: list[int]
+
+    def build_open_valve_obj(
+        self, valve_id: int = 0, duration_seconds: int = 0
+    ) -> EgressMessageList: ...
+
+    def build_close_valve_obj(self, valve_id: int = 0) -> EgressMessageList: ...
 
 
 async def async_setup_entry(
@@ -94,7 +105,7 @@ class GardenaValve(GardenaEntity, ValveEntity):
         self._entry = entry
         self._valve_id = valve_id
         self._attr_unique_id = f"{device.id}_valve_{valve_id}"
-        if len(device.valve_ids) > 1:
+        if len(cast(_ValveCapableDevice, device).valve_ids) > 1:
             self._attr_translation_key = "valve"
             self._attr_translation_placeholders = {"number": str(valve_id + 1)}
         else:
@@ -131,7 +142,9 @@ class GardenaValve(GardenaEntity, ValveEntity):
             )
             duration = minutes * 60
         await self._send_confirmed_command(
-            self._device.build_open_valve_obj(self._valve_id, duration)
+            cast(_ValveCapableDevice, self._device).build_open_valve_obj(
+                self._valve_id, duration
+            )
         )
         _LOGGER.info(
             "Opening valve %s valve_id=%s duration=%s seconds",
@@ -142,6 +155,8 @@ class GardenaValve(GardenaEntity, ValveEntity):
 
     async def async_close_valve(self, **kwargs: Any) -> None:
         await self._send_confirmed_command(
-            self._device.build_close_valve_obj(self._valve_id)
+            cast(_ValveCapableDevice, self._device).build_close_valve_obj(
+                self._valve_id
+            )
         )
         _LOGGER.info("Closing valve %s valve_id=%s", self._device.id, self._valve_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,3 +20,7 @@ dev = [
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+
+[tool.coverage.run]
+relative_files = true
+source = ["custom_components/gardena_smart_local_preview"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
     "reuse>=6.2.0",
     "pytest-homeassistant-custom-component>=0.13",
     "gardena-smart-local-api==0.1.3",
+    "ty>=0.0.59",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,23 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
+from typing import Self
+from unittest.mock import MagicMock
+
+import aiohttp
 import pytest
+import pytest_asyncio
+from homeassistant.helpers import entity_platform
+from pytest_homeassistant_custom_component.common import (
+    MockConfigEntry,
+    MockEntityPlatform,
+)
+
+from custom_components.gardena_smart_local_preview.const import DOMAIN
+from custom_components.gardena_smart_local_preview.coordinator import (
+    GardenaSmartLocalCoordinator,
+)
 
 pytest_plugins = ["pytest_homeassistant_custom_component"]
 
@@ -11,3 +27,168 @@ pytest_plugins = ["pytest_homeassistant_custom_component"]
 def auto_enable_custom_integrations(enable_custom_integrations):
     """Enable loading of the custom integration in all tests."""
     return enable_custom_integrations
+
+
+@pytest.fixture
+def mock_device():
+    """Factory for a MagicMock standing in for a gardena_smart_local_api Device."""
+
+    def _make(
+        device_id: str = "device-1",
+        is_online: bool = True,
+        name: str = "Water Control",
+        model_number: str = "MOD-1",
+        serial_number: str = "SN123",
+    ) -> MagicMock:
+        device = MagicMock()
+        device.id = device_id
+        device.is_online = is_online
+        device.model_definition.name = name
+        device.model_definition.model_number = model_number
+        device.serial_number = serial_number
+        device.software_version = "1.0"
+        device.hardware_version = "2.0"
+        return device
+
+    return _make
+
+
+@pytest.fixture
+def spec_device():
+    """Factory for a MagicMock(spec=...) standing in for a concrete Device subclass.
+
+    Unlike `mock_device`, this restricts attribute access to what the real
+    class actually defines, so `hasattr`/`isinstance` gates in platform
+    `async_setup_entry` functions behave like they would against the real
+    device.
+    """
+
+    def _make(
+        spec_cls: type,
+        device_id: str = "device-1",
+        is_online: bool = True,
+        name: str = "Test Device",
+        model_number: str = "MOD-1",
+        serial_number: str = "SN123",
+        **attrs: object,
+    ) -> MagicMock:
+        # dir(spec_cls) misses pydantic model fields (id/data/model_definition),
+        # which have no class-level attribute of their own; union them in so
+        # the mock still restricts hasattr()/isinstance() like the real class.
+        attr_names = set(dir(spec_cls)) | set(spec_cls.model_fields)
+        device = MagicMock(spec=list(attr_names))
+        device.__class__ = spec_cls
+        device.id = device_id
+        device.is_online = is_online
+        device.model_definition.name = name
+        device.model_definition.model_number = model_number
+        device.serial_number = serial_number
+        device.software_version = "1.0"
+        device.hardware_version = "2.0"
+        for key, value in attrs.items():
+            setattr(device, key, value)
+        return device
+
+    return _make
+
+
+@pytest_asyncio.fixture
+async def coordinator(hass):
+    """A real GardenaSmartLocalCoordinator bound to the test hass instance."""
+    coord = GardenaSmartLocalCoordinator(hass, "192.168.1.50", 8080, "secret")
+    yield coord
+    await coord.async_disconnect()
+
+
+@pytest.fixture
+def entry(coordinator):
+    """A MockConfigEntry wired up with the real `coordinator` fixture as runtime_data."""
+    config_entry = MockConfigEntry(domain=DOMAIN, data={})
+    config_entry.runtime_data = coordinator
+    return config_entry
+
+
+@pytest.fixture
+def sync_devices(coordinator):
+    """Publishes `coordinator._devices` as `coordinator.data` and fires listeners.
+
+    Entity state properties read `coordinator.data`, which is distinct from
+    `coordinator._devices` until this is called (mirrors real discovery).
+    """
+
+    def _sync() -> None:
+        coordinator.async_set_updated_data(coordinator._devices)
+
+    return _sync
+
+
+@pytest.fixture
+def setup_platform(hass):
+    """Runs a platform module's async_setup_entry and returns the async_add_entities mock.
+
+    Registers the coordinator listener; tests then populate
+    `coordinator._devices` and call `coordinator.async_set_updated_data(...)`
+    to trigger it, mirroring real dynamic device discovery.
+    """
+
+    async def _setup(module, config_entry) -> MagicMock:
+        async_add_entities = MagicMock()
+        # Modules that register entity services (e.g. valve.py's open_valve)
+        # call entity_platform.async_get_current_platform(), which reads a
+        # contextvar only the real EntityPlatform setup flow normally sets.
+        platform = MockEntityPlatform(hass, platform_name=DOMAIN)
+        token = entity_platform.current_platform.set(platform)
+        try:
+            await module.async_setup_entry(hass, config_entry, async_add_entities)
+        finally:
+            entity_platform.current_platform.reset(token)
+        return async_add_entities
+
+    return _setup
+
+
+class FakeWebSocket:
+    """Minimal stand-in for aiohttp.ClientWebSocketResponse.
+
+    After exhausting `messages`, iteration blocks (like an idle open
+    connection) until `simulate_close()` is called, instead of ending the
+    async-for immediately.
+    """
+
+    def __init__(self, messages: list[aiohttp.WSMessage] | None = None) -> None:
+        self.messages = messages or []
+        self.sent: list[str] = []
+        self.closed = False
+        self.close_code = 1000
+        self._exception: Exception | None = None
+        self._closed_event = asyncio.Event()
+
+    def exception(self) -> Exception | None:
+        return self._exception
+
+    async def send_str(self, data: str) -> None:
+        self.sent.append(data)
+
+    def simulate_close(self, exception: Exception | None = None) -> None:
+        self._exception = exception
+        self.closed = True
+        self._closed_event.set()
+
+    def __aiter__(self):
+        return self._aiter()
+
+    async def _aiter(self):
+        for msg in self.messages:
+            yield msg
+        await self._closed_event.wait()
+
+    async def __aenter__(self) -> Self:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> bool:
+        return False
+
+
+@pytest.fixture
+def fake_ws():
+    return FakeWebSocket

--- a/tests/test_binary_sensor.py
+++ b/tests/test_binary_sensor.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local frost-warning binary sensor."""
+
+from __future__ import annotations
+
+from gardena_smart_local_api.devices import Gen1WaterControl, PowerAdapter
+
+from custom_components.gardena_smart_local_preview import binary_sensor
+
+
+async def test_setup_adds_frost_sensor_for_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(binary_sensor, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], binary_sensor.GardenaFrostWarningSensor)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_skips_non_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(binary_sensor, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(binary_sensor, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(binary_sensor, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+def test_is_on_true(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", has_frost_warning=True)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = binary_sensor.GardenaFrostWarningSensor(coordinator, device)
+    assert entity.is_on is True
+
+
+def test_is_on_false(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Gen1WaterControl, device_id="device-1", has_frost_warning=False
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = binary_sensor.GardenaFrostWarningSensor(coordinator, device)
+    assert entity.is_on is False
+
+
+def test_is_on_none_when_device_missing(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", has_frost_warning=True)
+    sync_devices()
+    entity = binary_sensor.GardenaFrostWarningSensor(coordinator, device)
+    assert entity.is_on is None

--- a/tests/test_button.py
+++ b/tests/test_button.py
@@ -1,0 +1,139 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local button entities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from gardena_smart_local_api.devices import Gen2Mower, PowerAdapter, Pump
+
+from custom_components.gardena_smart_local_preview import button
+
+
+async def test_setup_adds_identify_button_for_identify_capable_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(button, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 2
+    assert isinstance(entities[0], button.GardenaIdentifyButton)
+    assert isinstance(entities[1], button.GardenaClearSchedulesButton)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_adds_five_buttons_for_pump_in_one_call(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(button, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 5
+    assert isinstance(entities[0], button.GardenaIdentifyButton)
+    assert isinstance(entities[1], button.GardenaPumpResetFlowButton)
+    assert isinstance(entities[2], button.GardenaPumpResetValveErrorsButton)
+    assert isinstance(entities[3], button.GardenaPumpResetTemperatureMinMaxButton)
+    assert isinstance(entities[4], button.GardenaClearSchedulesButton)
+
+
+async def test_setup_skips_non_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(button, entry)
+    device = spec_device(Gen2Mower, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(button, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(button, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+async def test_identify_button_press(coordinator, spec_device) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = button.GardenaIdentifyButton(coordinator, device)
+
+    await entity.async_press()
+
+    device.build_identify_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_identify_obj.return_value, wait_for_response_sec=10
+    )
+
+
+async def test_pump_reset_flow_button_press(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = button.GardenaPumpResetFlowButton(coordinator, device)
+
+    await entity.async_press()
+
+    device.build_reset_flow_resettable_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_reset_flow_resettable_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+async def test_pump_reset_valve_errors_button_press(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = button.GardenaPumpResetValveErrorsButton(coordinator, device)
+
+    await entity.async_press()
+
+    device.build_reset_all_valve_errors_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_reset_all_valve_errors_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+async def test_pump_reset_temperature_min_max_button_press(
+    coordinator, spec_device
+) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = button.GardenaPumpResetTemperatureMinMaxButton(coordinator, device)
+
+    await entity.async_press()
+
+    device.build_reset_outlet_temperature_min_max_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_reset_outlet_temperature_min_max_obj.return_value,
+        wait_for_response_sec=10,
+    )

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,980 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local websocket coordinator."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+from gardena_smart_local_api.devices import DeviceMap
+from gardena_smart_local_api.messages import (
+    Entity,
+    Event,
+    IngressMessageList,
+    Reply,
+)
+from gardena_smart_local_api.resources import IpsoPath
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.gardena_smart_local_preview import (
+    coordinator as coordinator_module,
+)
+from custom_components.gardena_smart_local_preview.coordinator import (
+    GardenaSmartLocalCoordinator,
+    IncludableDeviceInfo,
+)
+
+PATCH_CLIENTSESSION = (
+    "custom_components.gardena_smart_local_preview.coordinator.async_get_clientsession"
+)
+
+
+async def _pump() -> None:
+    """Let pending coroutines/background tasks progress."""
+    await asyncio.sleep(0.05)
+
+
+def _session_with(ws_side_effect) -> MagicMock:
+    session = MagicMock()
+    session.ws_connect = MagicMock(side_effect=ws_side_effect)
+    return session
+
+
+def _includable_event(
+    instance_id: str = "instance-1",
+    op: str = "update",
+    service: str | None = "some-service",
+    identifier: str | None = "ABCDEF0123456789ABCDEF01",
+) -> Event:
+    payload = {"identifier": {"vs": identifier}} if identifier is not None else {}
+    return Event(
+        op=op,
+        payload=payload,
+        entity=Entity(
+            service=service,
+            path=IpsoPath(
+                object_name="includable_device", object_instance_id=instance_id
+            ),
+        ),
+    )
+
+
+async def test_async_update_data_returns_devices(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._devices["device-1"] = mock_device(device_id="device-1")
+    assert await coordinator._async_update_data() is coordinator._devices
+
+
+# ---------------------------------------------------------------------------
+# Connection lifecycle: async_connect / _ws_loop / async_disconnect
+# ---------------------------------------------------------------------------
+
+
+async def test_async_connect_sets_up_task_and_ssl_context(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    coordinator._do_discovery = AsyncMock()
+    ws = fake_ws()
+    session = _session_with([ws])
+
+    with patch(PATCH_CLIENTSESSION, return_value=session):
+        await coordinator.async_connect()
+        await _pump()
+
+        assert coordinator._task is not None
+        assert coordinator._ssl_context is not None
+        coordinator._do_discovery.assert_awaited_once()
+        assert coordinator._ws is ws
+
+    await coordinator.async_disconnect()
+    assert coordinator._ws is None
+    assert coordinator._pending_replies == {}
+
+
+async def test_ws_loop_reconnects_after_reader_exit(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    fake_ws,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator._do_discovery = AsyncMock()
+    closed_ws = fake_ws(
+        messages=[aiohttp.WSMessage(aiohttp.WSMsgType.CLOSED, None, None)]
+    )
+    session = _session_with([closed_ws, asyncio.CancelledError()])
+
+    with (
+        patch(PATCH_CLIENTSESSION, return_value=session),
+        caplog.at_level(logging.INFO),
+    ):
+        await coordinator.async_connect()
+        await _pump()
+
+    assert session.ws_connect.call_count == 2
+    assert "Disconnected from GARDENA smart Gateway, reconnecting" in caplog.text
+    assert coordinator._task.done()
+
+
+async def test_ws_loop_reconnects_after_exception(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    fake_ws,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator._do_discovery = AsyncMock()
+    session = _session_with(
+        [aiohttp.ClientConnectionError("boom"), asyncio.CancelledError()]
+    )
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    with (
+        patch(PATCH_CLIENTSESSION, return_value=session),
+        patch.object(coordinator_module.asyncio, "sleep", fake_sleep),
+        caplog.at_level(logging.ERROR),
+    ):
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await coordinator.async_connect()
+        await real_sleep(0.05)
+
+    assert sleep_calls == [5]
+    assert "WebSocket error: boom" in caplog.text
+    assert session.ws_connect.call_count == 2
+
+
+async def test_ws_loop_cancelled_on_connect_breaks_cleanly(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    session = _session_with([asyncio.CancelledError()])
+
+    with (
+        patch(PATCH_CLIENTSESSION, return_value=session),
+        caplog.at_level(logging.ERROR),
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.async_connect()
+        await _pump()
+
+    assert coordinator._task.done()
+    assert "WebSocket error" not in caplog.text
+
+
+async def test_async_disconnect_noop_when_never_connected(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    assert coordinator._task is None
+    await coordinator.async_disconnect()
+
+
+async def test_ws_loop_finally_cancels_pending_reply_futures(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    fake_ws,
+) -> None:
+    coordinator._do_discovery = AsyncMock()
+    ws = fake_ws()
+    session = _session_with([ws, asyncio.CancelledError()])
+
+    with patch(PATCH_CLIENTSESSION, return_value=session):
+        await coordinator.async_connect()
+        await _pump()
+
+        loop = asyncio.get_running_loop()
+        pending = loop.create_future()
+        coordinator._pending_replies["req-1"] = pending
+
+        ws.simulate_close()
+        await _pump()
+
+    assert pending.cancelled()
+    assert coordinator._pending_replies == {}
+
+
+async def test_async_disconnect_cancels_includable_timers(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    handle = MagicMock()
+    coordinator._includable_timeouts["instance-1"] = handle
+
+    await coordinator.async_disconnect()
+
+    handle.cancel.assert_called_once()
+    assert coordinator._includable_timeouts == {}
+
+
+# ---------------------------------------------------------------------------
+# _ws_reader
+# ---------------------------------------------------------------------------
+
+
+async def test_ws_reader_text_message_queued(
+    coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    ws = fake_ws(
+        messages=[
+            aiohttp.WSMessage(aiohttp.WSMsgType.TEXT, "hello", None),
+            aiohttp.WSMessage(aiohttp.WSMsgType.CLOSED, None, None),
+        ]
+    )
+    await coordinator._ws_reader(ws)
+    assert coordinator._msg_queue.get_nowait() == "hello"
+
+
+async def test_ws_reader_binary_message_decoded_and_queued(
+    coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    ws = fake_ws(
+        messages=[
+            aiohttp.WSMessage(aiohttp.WSMsgType.BINARY, b"hello", None),
+            aiohttp.WSMessage(aiohttp.WSMsgType.CLOSED, None, None),
+        ]
+    )
+    await coordinator._ws_reader(ws)
+    assert coordinator._msg_queue.get_nowait() == "hello"
+
+
+async def test_ws_reader_error_breaks_and_logs(
+    coordinator: GardenaSmartLocalCoordinator,
+    fake_ws,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ws = fake_ws(messages=[aiohttp.WSMessage(aiohttp.WSMsgType.ERROR, None, None)])
+    ws._exception = RuntimeError("socket broke")
+
+    with caplog.at_level(logging.ERROR):
+        await coordinator._ws_reader(ws)
+
+    assert coordinator._msg_queue.empty()
+    assert "socket broke" in caplog.text
+
+
+async def test_ws_reader_closed_breaks(
+    coordinator: GardenaSmartLocalCoordinator,
+    fake_ws,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ws = fake_ws(messages=[aiohttp.WSMessage(aiohttp.WSMsgType.CLOSED, None, None)])
+
+    with caplog.at_level(logging.WARNING):
+        await coordinator._ws_reader(ws)
+
+    assert "Connection to GARDENA smart Gateway closed" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# _msg_consumer
+# ---------------------------------------------------------------------------
+
+
+async def test_msg_consumer_resolves_pending_reply_future(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    coordinator._handle_messages = AsyncMock()
+    loop = asyncio.get_running_loop()
+    future = loop.create_future()
+    coordinator._pending_replies["req-1"] = future
+
+    reply = Reply(request_id="req-1", success=True)
+    coordinator._msg_queue.put_nowait(IngressMessageList([reply]).model_dump_json())
+
+    task = hass.async_create_task(coordinator._msg_consumer())
+    await _pump()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert future.done()
+    assert future.result().request_id == "req-1"
+    coordinator._handle_messages.assert_not_awaited()
+
+
+async def test_msg_consumer_forwards_non_reply_to_handle_messages(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    coordinator._handle_messages = AsyncMock()
+    event = _includable_event()
+    coordinator._msg_queue.put_nowait(IngressMessageList([event]).model_dump_json())
+
+    task = hass.async_create_task(coordinator._msg_consumer())
+    await _pump()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    coordinator._handle_messages.assert_awaited_once()
+    (forwarded,), _ = coordinator._handle_messages.call_args
+    assert len(forwarded) == 1
+
+
+async def test_msg_consumer_ignores_malformed_json(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    coordinator._handle_messages = AsyncMock()
+    coordinator._msg_queue.put_nowait("not valid json")
+    event = _includable_event()
+    coordinator._msg_queue.put_nowait(IngressMessageList([event]).model_dump_json())
+
+    task = hass.async_create_task(coordinator._msg_consumer())
+    await _pump()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    coordinator._handle_messages.assert_awaited_once()
+
+
+async def test_msg_consumer_exception_logged_and_reraised(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator._handle_messages = AsyncMock(side_effect=RuntimeError("boom"))
+    event = _includable_event()
+    coordinator._msg_queue.put_nowait(IngressMessageList([event]).model_dump_json())
+
+    task = hass.async_create_task(coordinator._msg_consumer())
+    with caplog.at_level(logging.ERROR), pytest.raises(RuntimeError):
+        await task
+
+    assert "Message consumer failed" in caplog.text
+
+
+async def test_msg_consumer_cancelled_reraises(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    task = hass.async_create_task(coordinator._msg_consumer())
+    await _pump()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert task.cancelled()
+
+
+# ---------------------------------------------------------------------------
+# _do_discovery
+# ---------------------------------------------------------------------------
+
+
+def _device_map(**devices) -> DeviceMap:
+    dm = DeviceMap({})
+    for device_id, device in devices.items():
+        dm[device_id] = device
+    return dm
+
+
+async def test_do_discovery_success_broadcasts_by_default(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator.send_request = AsyncMock(return_value=IngressMessageList([]))
+    device = mock_device(device_id="device-1")
+    with (
+        patch.object(
+            coordinator_module,
+            "create_devices_from_messages",
+            AsyncMock(return_value=_device_map(**{"device-1": device})),
+        ),
+        patch.object(coordinator, "async_set_updated_data") as set_updated,
+    ):
+        await coordinator._do_discovery()
+
+    coordinator.send_request.assert_awaited_once()
+    call = coordinator.send_request.await_args
+    assert call.args[0] == "discovery"
+    assert call.kwargs == {"wait_for_response_sec": 30}
+    assert coordinator._devices["device-1"] is device
+    set_updated.assert_called_once_with(coordinator._devices)
+
+
+async def test_do_discovery_broadcast_false_skips_set_updated_data(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator.send_request = AsyncMock(return_value=IngressMessageList([]))
+    device = mock_device(device_id="device-1")
+    with (
+        patch.object(
+            coordinator_module,
+            "create_devices_from_messages",
+            AsyncMock(return_value=_device_map(**{"device-1": device})),
+        ),
+        patch.object(coordinator, "async_set_updated_data") as set_updated,
+    ):
+        await coordinator._do_discovery(broadcast=False)
+
+    set_updated.assert_not_called()
+
+
+async def test_do_discovery_timeout_raises_runtime_error(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator.send_request = AsyncMock(side_effect=TimeoutError())
+
+    with pytest.raises(RuntimeError):
+        await coordinator._do_discovery()
+
+
+# ---------------------------------------------------------------------------
+# _handle_messages
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_messages_delete_event_drops_device(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    device = mock_device(device_id="device-1")
+    coordinator._devices["device-1"] = device
+    coordinator.async_drop_device = MagicMock()
+
+    event = Event(
+        op="delete", entity=Entity(device="device-1", path=IpsoPath()), payload={}
+    )
+    await coordinator._handle_messages(IngressMessageList([event]))
+
+    coordinator.async_drop_device.assert_called_once_with("device-1")
+
+
+async def test_handle_messages_update_event_updates_device_and_batches_broadcast(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    device_a = mock_device(device_id="device-a", is_online=True)
+    device_b = mock_device(device_id="device-b", is_online=True)
+    coordinator._devices["device-a"] = device_a
+    coordinator._devices["device-b"] = device_b
+
+    event_a = Event(
+        op="update",
+        entity=Entity(device="device-a", path=IpsoPath(object_name="sensor")),
+        payload={"vb": True},
+    )
+    event_b = Event(
+        op="update",
+        entity=Entity(device="device-b", path=IpsoPath(object_name="sensor")),
+        payload={"vb": True},
+    )
+
+    with patch.object(coordinator, "async_set_updated_data") as set_updated:
+        await coordinator._handle_messages(IngressMessageList([event_a, event_b]))
+
+    device_a.update_data.assert_called_once_with(event_a)
+    device_b.update_data.assert_called_once_with(event_b)
+    set_updated.assert_called_once_with(coordinator._devices)
+
+
+async def test_handle_messages_logs_online_status_change(
+    coordinator: GardenaSmartLocalCoordinator,
+    mock_device,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    device = mock_device(device_id="device-1", is_online=True)
+
+    def _go_offline(_event: Event) -> None:
+        device.is_online = False
+
+    device.update_data.side_effect = _go_offline
+    coordinator._devices["device-1"] = device
+
+    event = Event(
+        op="update",
+        entity=Entity(device="device-1", path=IpsoPath(object_name="sensor")),
+        payload={},
+    )
+    with caplog.at_level(logging.INFO):
+        await coordinator._handle_messages(IngressMessageList([event]))
+
+    assert "connection status changed" in caplog.text
+
+
+async def test_handle_messages_event_without_device_id_ignored(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    event = Event(op="update", entity=Entity(path=IpsoPath()), payload={})
+    with patch.object(coordinator, "async_set_updated_data") as set_updated:
+        await coordinator._handle_messages(IngressMessageList([event]))
+    set_updated.assert_not_called()
+
+
+async def test_handle_messages_includable_event_routed(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._handle_includable_event = AsyncMock()
+    event = _includable_event()
+    await coordinator._handle_messages(IngressMessageList([event]))
+    coordinator._handle_includable_event.assert_awaited_once_with(event)
+
+
+async def test_handle_messages_exception_caught_and_logged(
+    coordinator: GardenaSmartLocalCoordinator,
+    mock_device,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    device = mock_device(device_id="device-1")
+    device.update_data.side_effect = RuntimeError("boom")
+    coordinator._devices["device-1"] = device
+
+    event = Event(
+        op="update",
+        entity=Entity(device="device-1", path=IpsoPath(object_name="sensor")),
+        payload={},
+    )
+    with caplog.at_level(logging.WARNING):
+        await coordinator._handle_messages(IngressMessageList([event]))
+
+    assert "Error handling messages" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Includable device discovery
+# ---------------------------------------------------------------------------
+
+
+async def test_handle_includable_event_missing_instance_id_noop(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    event = Event(
+        op="update",
+        entity=Entity(path=IpsoPath(object_name="includable_device")),
+        payload={},
+    )
+    await coordinator._handle_includable_event(event)
+    assert coordinator.includable_devices == {}
+
+
+async def test_handle_includable_event_delete_removes_entry(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    handle = MagicMock()
+    coordinator._includable_timeouts["instance-1"] = handle
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1",
+        service="svc",
+        device_id="device-1",
+        device_name="Device",
+    )
+
+    event = _includable_event(op="delete")
+    await coordinator._handle_includable_event(event)
+
+    handle.cancel.assert_called_once()
+    assert coordinator.includable_devices == {}
+
+
+async def test_handle_includable_event_new_device_discovered(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    sgtin = MagicMock()
+    sgtin.serial = 42
+    sgtin.get_model_name = AsyncMock(return_value="Water Control")
+
+    event = _includable_event(identifier="ABCDEF0123456789ABCDEF01")
+    with patch.object(coordinator_module.SGTIN96Info, "from_hex", return_value=sgtin):
+        await coordinator._handle_includable_event(event)
+
+    assert "instance-1" in coordinator.includable_devices
+    info = coordinator.includable_devices["instance-1"]
+    assert info.device_id == "ABCDEF0123456789ABCDEF01"
+    assert info.device_name == "Water Control 00000042"
+    assert "instance-1" in coordinator._includable_timeouts
+
+    coordinator._includable_timeouts.pop("instance-1").cancel()
+
+
+async def test_handle_includable_event_heartbeat_reschedules_only(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    old_handle = MagicMock()
+    coordinator._includable_timeouts["instance-1"] = old_handle
+
+    event = _includable_event()
+    await coordinator._handle_includable_event(event)
+
+    old_handle.cancel.assert_called_once()
+    assert len(coordinator.includable_devices) == 1
+    coordinator._includable_timeouts.pop("instance-1").cancel()
+
+
+async def test_handle_includable_event_unparseable_identifier_ignored(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    event = _includable_event(identifier="not-a-valid-sgtin")
+    await coordinator._handle_includable_event(event)
+    assert coordinator.includable_devices == {}
+
+
+async def test_handle_includable_event_missing_service_ignored(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    event = _includable_event(service=None)
+    await coordinator._handle_includable_event(event)
+    assert coordinator.includable_devices == {}
+
+
+async def test_handle_includable_event_missing_identifier_ignored(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    event = _includable_event(identifier=None)
+    await coordinator._handle_includable_event(event)
+    assert coordinator.includable_devices == {}
+
+
+def test_expire_includable_removes_entry(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator._includable_timeouts["instance-1"] = MagicMock()
+
+    coordinator._expire_includable("instance-1")
+
+    assert coordinator.includable_devices == {}
+    assert coordinator._includable_timeouts == {}
+
+
+# ---------------------------------------------------------------------------
+# async_include_device
+# ---------------------------------------------------------------------------
+
+
+async def test_async_include_device_unknown_instance_returns_none(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    assert await coordinator.async_include_device("unknown") is None
+
+
+async def test_async_include_device_send_request_timeout_returns_none(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator.send_request = AsyncMock(side_effect=TimeoutError())
+
+    assert await coordinator.async_include_device("instance-1") is None
+
+
+async def test_async_include_device_send_request_error_returns_none(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator.send_request = AsyncMock(side_effect=RuntimeError("boom"))
+
+    assert await coordinator.async_include_device("instance-1") is None
+
+
+async def test_async_include_device_no_successful_reply_returns_none(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="instance-1", success=False)])
+    )
+
+    assert await coordinator.async_include_device("instance-1") is None
+
+
+async def test_async_include_device_completion_timeout_returns_none(
+    coordinator: GardenaSmartLocalCoordinator, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(coordinator_module, "INCLUSION_TIMEOUT", 2)
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="instance-1", success=True)])
+    )
+
+    with patch.object(coordinator_module.asyncio, "sleep", AsyncMock()):
+        result = await coordinator.async_include_device("instance-1")
+
+    assert result is None
+    assert "instance-1" in coordinator._includable_devices
+
+
+def _pop_includable_on_sleep(
+    coordinator: GardenaSmartLocalCoordinator, instance_id: str
+):
+    """asyncio.sleep replacement that removes the includable device on first call."""
+
+    async def fake_sleep(_delay: float) -> None:
+        coordinator._includable_devices.pop(instance_id, None)
+
+    return fake_sleep
+
+
+async def test_async_include_device_rediscovery_failure_returns_none(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="instance-1", success=True)])
+    )
+    coordinator._do_discovery = AsyncMock(side_effect=RuntimeError("boom"))
+
+    with patch.object(
+        coordinator_module.asyncio,
+        "sleep",
+        _pop_includable_on_sleep(coordinator, "instance-1"),
+    ):
+        assert await coordinator.async_include_device("instance-1") is None
+
+
+async def test_async_include_device_missing_after_discovery_returns_none(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1", service="svc", device_id="d1", device_name="Device"
+    )
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="instance-1", success=True)])
+    )
+    coordinator._do_discovery = AsyncMock()
+
+    with patch.object(
+        coordinator_module.asyncio,
+        "sleep",
+        _pop_includable_on_sleep(coordinator, "instance-1"),
+    ):
+        assert await coordinator.async_include_device("instance-1") is None
+    coordinator._do_discovery.assert_awaited_once_with(broadcast=False)
+
+
+async def test_async_include_device_success(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._includable_devices["instance-1"] = IncludableDeviceInfo(
+        instance_id="instance-1",
+        service="svc",
+        device_id="device-1",
+        device_name="Device",
+    )
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="instance-1", success=True)])
+    )
+
+    async def fake_discovery(broadcast: bool = True) -> None:
+        coordinator._devices["device-1"] = mock_device(device_id="device-1")
+
+    coordinator._do_discovery = fake_discovery
+
+    with patch.object(
+        coordinator_module.asyncio,
+        "sleep",
+        _pop_includable_on_sleep(coordinator, "instance-1"),
+    ):
+        result = await coordinator.async_include_device("instance-1")
+    assert result == "device-1"
+
+
+# ---------------------------------------------------------------------------
+# async_drop_device / async_exclude_device
+# ---------------------------------------------------------------------------
+
+
+def test_async_drop_device_removes_and_broadcasts(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._devices["device-1"] = mock_device(device_id="device-1")
+    with patch.object(coordinator, "async_set_updated_data") as set_updated:
+        coordinator.async_drop_device("device-1")
+    set_updated.assert_called_once_with(coordinator._devices)
+    assert "device-1" not in coordinator._devices
+
+
+def test_async_drop_device_unknown_is_noop(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    with patch.object(coordinator, "async_set_updated_data") as set_updated:
+        coordinator.async_drop_device("unknown")
+    set_updated.assert_not_called()
+
+
+async def test_async_exclude_device_unknown_returns_false(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    assert await coordinator.async_exclude_device("unknown") is False
+
+
+async def test_async_exclude_device_success_drops_before_request(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    device = mock_device(device_id="device-1")
+    coordinator._devices["device-1"] = device
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="req-1", success=True)])
+    )
+
+    result = await coordinator.async_exclude_device("device-1")
+
+    assert result is True
+    assert "device-1" not in coordinator._devices
+    device.build_exclusion_obj.assert_called_once()
+
+
+async def test_async_exclude_device_timeout_returns_false(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._devices["device-1"] = mock_device(device_id="device-1")
+    coordinator.send_request = AsyncMock(side_effect=TimeoutError())
+
+    assert await coordinator.async_exclude_device("device-1") is False
+
+
+async def test_async_exclude_device_error_returns_false(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._devices["device-1"] = mock_device(device_id="device-1")
+    coordinator.send_request = AsyncMock(side_effect=RuntimeError("boom"))
+
+    assert await coordinator.async_exclude_device("device-1") is False
+
+
+async def test_async_exclude_device_no_success_reply_returns_false(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._devices["device-1"] = mock_device(device_id="device-1")
+    coordinator.send_request = AsyncMock(
+        return_value=IngressMessageList([Reply(request_id="req-1", success=False)])
+    )
+
+    assert await coordinator.async_exclude_device("device-1") is False
+
+
+# ---------------------------------------------------------------------------
+# _update_device / _update_devices
+# ---------------------------------------------------------------------------
+
+
+def test_update_device_adds_new_device(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    device = mock_device(device_id="device-1")
+    coordinator._update_device(device)
+    assert coordinator._devices["device-1"] is device
+
+
+def test_update_device_updates_existing_device(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    old = mock_device(device_id="device-1")
+    new = mock_device(device_id="device-1")
+    coordinator._devices["device-1"] = old
+    coordinator._update_device(new)
+    assert coordinator._devices["device-1"] is new
+
+
+def test_update_devices_handles_exception(
+    coordinator: GardenaSmartLocalCoordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    bad_devices = MagicMock()
+    bad_devices.values.side_effect = RuntimeError("boom")
+
+    with caplog.at_level(logging.WARNING):
+        coordinator._update_devices(bad_devices)
+
+    assert "Failed to update devices" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# send_request
+# ---------------------------------------------------------------------------
+
+
+async def test_send_request_without_ws_raises(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    from gardena_smart_local_api.devices import build_discovery_obj
+
+    coordinator._ws = None
+    with pytest.raises(HomeAssistantError):
+        await coordinator.send_request("device-1", build_discovery_obj())
+
+
+async def test_send_request_with_closed_ws_raises(
+    coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    from gardena_smart_local_api.devices import build_discovery_obj
+
+    ws = fake_ws()
+    ws.closed = True
+    coordinator._ws = ws
+    with pytest.raises(HomeAssistantError):
+        await coordinator.send_request("device-1", build_discovery_obj())
+    assert ws.sent == []
+
+
+async def test_send_request_fire_and_forget(
+    coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    from gardena_smart_local_api.devices import build_discovery_obj
+
+    ws = fake_ws()
+    coordinator._ws = ws
+    result = await coordinator.send_request("device-1", build_discovery_obj())
+    assert list(result) == []
+    assert len(ws.sent) == 1
+    assert coordinator._pending_replies == {}
+
+
+async def test_send_request_waits_for_reply(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    from gardena_smart_local_api.messages import Request
+
+    ws = fake_ws()
+    coordinator._ws = ws
+    request = Request(op="read", entity=Entity(path=IpsoPath()), request_id="req-1")
+
+    async def resolve_soon() -> None:
+        await asyncio.sleep(0)
+        future = coordinator._pending_replies["req-1"]
+        future.set_result(Reply(request_id="req-1", success=True))
+
+    hass.async_create_task(resolve_soon())
+    from gardena_smart_local_api.messages import EgressMessageList
+
+    replies = list(
+        await coordinator.send_request(
+            "device-1", EgressMessageList([request]), wait_for_response_sec=5
+        )
+    )
+    assert len(replies) == 1
+    assert replies[0].request_id == "req-1"
+
+
+async def test_send_request_timeout_purges_pending(
+    coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    from gardena_smart_local_api.messages import EgressMessageList, Request
+
+    ws = fake_ws()
+    coordinator._ws = ws
+    request = Request(op="read", entity=Entity(path=IpsoPath()), request_id="req-1")
+
+    with pytest.raises(asyncio.TimeoutError):
+        await coordinator.send_request(
+            "device-1", EgressMessageList([request]), wait_for_response_sec=0.01
+        )
+
+    assert coordinator._pending_replies == {}

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,74 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local diagnostics."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.components.diagnostics import REDACTED
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.gardena_smart_local_preview import diagnostics
+from custom_components.gardena_smart_local_preview.const import DOMAIN
+
+
+def _entry(devices: dict | None) -> MockConfigEntry:
+    config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8080, CONF_PASSWORD: "secret"},
+        options={"some_option": "value"},
+    )
+    runtime_data = MagicMock()
+    runtime_data.data = MagicMock()
+    runtime_data.data.__bool__.return_value = devices is not None
+    runtime_data.data.model_dump.return_value = devices or {}
+
+    device_mock = None
+    if devices and "device-1" in devices:
+        device_mock = MagicMock()
+        device_mock.model_dump.return_value = devices["device-1"]
+    runtime_data.data.get.return_value = device_mock
+
+    config_entry.runtime_data = runtime_data
+    return config_entry
+
+
+async def test_config_entry_diagnostics_redacts_password(hass) -> None:
+    entry = _entry({"device-1": {"id": "device-1"}})
+
+    result = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["entry_data"][CONF_PASSWORD] == REDACTED
+    assert result["entry_data"][CONF_HOST] == "192.168.1.50"
+    assert result["entry_options"] == {"some_option": "value"}
+    assert result["devices"] == {"device-1": {"id": "device-1"}}
+
+
+async def test_config_entry_diagnostics_handles_no_devices(hass) -> None:
+    entry = _entry(None)
+
+    result = await diagnostics.async_get_config_entry_diagnostics(hass, entry)
+
+    assert result["devices"] == {}
+
+
+async def test_device_diagnostics_returns_matching_device(hass) -> None:
+    entry = _entry({"device-1": {"id": "device-1", "name": "Water Control"}})
+    device_entry = MagicMock(identifiers={(DOMAIN, "device-1")})
+
+    result = await diagnostics.async_get_device_diagnostics(hass, entry, device_entry)
+
+    assert result["device"] == {"id": "device-1", "name": "Water Control"}
+
+
+async def test_device_diagnostics_returns_none_for_unmatched_device(hass) -> None:
+    entry = _entry({"device-1": {"id": "device-1"}})
+    device_entry = MagicMock(identifiers={("other_domain", "device-1")})
+
+    result = await diagnostics.async_get_device_diagnostics(hass, entry, device_entry)
+
+    assert result["device"] is None

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -16,6 +16,19 @@ from custom_components.gardena_smart_local_preview.entity import (
     GardenaEntity,
     find_device_subentry_id,
 )
+
+PATCH_DR_ASYNC_GET = "custom_components.gardena_smart_local_preview.entity.dr.async_get"
+
+
+def _make_entity_for_update_test(
+    coordinator, device
+) -> tuple[GardenaEntity, MagicMock]:
+    """Build a GardenaEntity wired up enough to exercise _handle_coordinator_update."""
+    entity = GardenaEntity(coordinator, device)
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    entity.device_entry = MagicMock(id="registry-device-id", sw_version="0.9")
+    return entity, entity.device_entry
 
 
 def _make_entry_with_subentries(subentries: dict) -> MockConfigEntry:
@@ -98,3 +111,91 @@ def test_gardena_entity_unavailable_when_missing_from_coordinator_data(
     entity = GardenaEntity(coordinator, device)
 
     assert entity.available is False
+
+
+# ---------------------------------------------------------------------------
+# _handle_coordinator_update: device registry sw_version sync
+# ---------------------------------------------------------------------------
+
+
+def test_handle_coordinator_update_syncs_changed_sw_version(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "1.1"
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, device_entry = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_called_once_with(
+        device_entry.id, sw_version="1.1"
+    )
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_sw_version_unchanged(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "0.9"
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_device_missing(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "1.1"
+    coordinator = MagicMock()
+    coordinator.data = {}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_no_software_version(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = None
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_no_device_entry(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "1.1"
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    entity.device_entry = None
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local shared entity base."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from homeassistant.helpers import device_registry as dr
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.gardena_smart_local_preview.const import DOMAIN
+from custom_components.gardena_smart_local_preview.entity import (
+    GardenaEntity,
+    find_device_subentry_id,
+)
+
+
+def _make_entry_with_subentries(subentries: dict) -> MockConfigEntry:
+    entry = MockConfigEntry(domain=DOMAIN, data={})
+    entry.subentries = subentries
+    return entry
+
+
+def _make_subentry(device_id: str) -> MagicMock:
+    subentry = MagicMock()
+    subentry.data = {"device_id": device_id}
+    return subentry
+
+
+def test_find_device_subentry_id_match() -> None:
+    entry = _make_entry_with_subentries({"sub-1": _make_subentry("device-1")})
+    assert find_device_subentry_id(entry, "device-1") == "sub-1"
+
+
+def test_find_device_subentry_id_no_match() -> None:
+    entry = _make_entry_with_subentries({"sub-1": _make_subentry("device-1")})
+    assert find_device_subentry_id(entry, "device-2") is None
+
+
+def test_find_device_subentry_id_empty_subentries() -> None:
+    entry = _make_entry_with_subentries({})
+    assert find_device_subentry_id(entry, "device-1") is None
+
+
+def test_gardena_entity_device_info(mock_device) -> None:
+    device = mock_device(
+        device_id="device-1",
+        name="Water Control",
+        model_number="MOD-1",
+        serial_number="SN123",
+    )
+    coordinator = MagicMock()
+
+    entity = GardenaEntity(coordinator, device)
+
+    assert entity._attr_device_info == dr.DeviceInfo(
+        identifiers={(DOMAIN, "device-1")},
+        name="GARDENA Water Control SN123",
+        manufacturer="GARDENA",
+        model="Water Control",
+        model_id="MOD-1",
+        sw_version="1.0",
+        hw_version="2.0",
+        serial_number="SN123",
+    )
+
+
+def test_gardena_entity_available_when_online(mock_device) -> None:
+    device = mock_device(device_id="device-1", is_online=True)
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity = GardenaEntity(coordinator, device)
+
+    assert entity.available is True
+
+
+def test_gardena_entity_unavailable_when_offline(mock_device) -> None:
+    device = mock_device(device_id="device-1", is_online=False)
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity = GardenaEntity(coordinator, device)
+
+    assert entity.available is False
+
+
+def test_gardena_entity_unavailable_when_missing_from_coordinator_data(
+    mock_device,
+) -> None:
+    device = mock_device(device_id="device-1", is_online=True)
+    coordinator = MagicMock()
+    coordinator.data = {}
+
+    entity = GardenaEntity(coordinator, device)
+
+    assert entity.available is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local integration setup/unload."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    ConfigEntryChange,
+    ConfigEntryState,
+)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.gardena_smart_local_preview import DOMAIN, async_setup
+from custom_components.gardena_smart_local_preview.coordinator import (
+    GardenaSmartLocalCoordinator,
+)
+
+PATCH_CONNECT = (
+    "custom_components.gardena_smart_local_preview.coordinator."
+    "GardenaSmartLocalCoordinator.async_connect"
+)
+PATCH_DISCONNECT = (
+    "custom_components.gardena_smart_local_preview.coordinator."
+    "GardenaSmartLocalCoordinator.async_disconnect"
+)
+
+
+def _mock_connect():
+    return patch(PATCH_CONNECT, AsyncMock())
+
+
+def _mock_disconnect():
+    return patch(PATCH_DISCONNECT, AsyncMock())
+
+
+async def test_async_setup_without_domain_config_is_noop(hass) -> None:
+    result = await async_setup(hass, {})
+
+    assert result is True
+    assert hass.config_entries.async_entries(DOMAIN) == []
+
+
+async def test_async_setup_imports_yaml_config(hass) -> None:
+    with _mock_connect(), _mock_disconnect():
+        result = await async_setup(
+            hass,
+            {
+                DOMAIN: {
+                    CONF_HOST: "192.168.1.50",
+                    CONF_PORT: 8443,
+                    CONF_PASSWORD: "secret",
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result is True
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data[CONF_HOST] == "192.168.1.50"
+
+
+async def test_setup_entry_connects_and_forwards_platforms(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect() as mock_connect, _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert isinstance(entry.runtime_data, GardenaSmartLocalCoordinator)
+    mock_connect.assert_called_once()
+
+
+async def test_setup_entry_creates_subentry_for_discovered_device(
+    hass, mock_device
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect(), _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        device = mock_device(device_id="device-1", name="Water Control")
+        coordinator._devices["device-1"] = device
+        coordinator.async_set_updated_data(coordinator._devices)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    subentries = list(entry.subentries.values())
+    assert len(subentries) == 1
+    assert subentries[0].data["device_id"] == "device-1"
+    assert subentries[0].title == "Water Control SN123"
+
+
+async def test_setup_entry_migrates_legacy_device_to_subentry(
+    hass, mock_device
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    dev_reg = dr.async_get(hass)
+    legacy_device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        config_subentry_id=None,
+        identifiers={(DOMAIN, "device-1")},
+    )
+
+    with _mock_connect(), _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        device = mock_device(device_id="device-1", name="Water Control")
+        coordinator._devices["device-1"] = device
+        coordinator.async_set_updated_data(coordinator._devices)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    updated_device = dev_reg.async_get(legacy_device.id)
+    assert updated_device is not None
+    subentry_id = next(iter(entry.subentries.keys()))
+    assert None not in updated_device.config_entries_subentries.get(
+        entry.entry_id, set()
+    )
+    assert subentry_id in updated_device.config_entries_subentries.get(
+        entry.entry_id, set()
+    )
+
+
+async def test_entry_updated_excludes_device_when_subentry_removed(
+    hass, mock_device
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect(), _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        device = mock_device(device_id="device-1", name="Water Control")
+        coordinator._devices["device-1"] = device
+        coordinator.async_set_updated_data(coordinator._devices)
+        await hass.async_block_till_done()
+
+        # Sync the closure's known-subentries cache with reality.
+        async_dispatcher_send(
+            hass, SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange.UPDATED, entry
+        )
+        await hass.async_block_till_done()
+
+        subentry_id = next(iter(entry.subentries.keys()))
+
+        with patch.object(
+            GardenaSmartLocalCoordinator, "async_exclude_device", AsyncMock()
+        ) as mock_exclude:
+            # Removing the subentry fires SIGNAL_CONFIG_ENTRY_CHANGED itself.
+            hass.config_entries.async_remove_subentry(entry, subentry_id)
+            await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_exclude.assert_called_once_with("device-1")
+
+
+async def test_unload_entry_disconnects_coordinator(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect(), _mock_disconnect() as mock_disconnect:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    mock_disconnect.assert_called_once()

--- a/tests/test_lawn_mower.py
+++ b/tests/test_lawn_mower.py
@@ -1,0 +1,153 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local lawn mower entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from gardena_smart_local_api.devices import (
+    Gen1Mower1,
+    Gen2Mower,
+    MowerState,
+    PowerAdapter,
+)
+from homeassistant.components.lawn_mower import (
+    LawnMowerActivity,
+    LawnMowerEntityFeature,
+)
+
+from custom_components.gardena_smart_local_preview import lawn_mower
+
+
+async def test_setup_adds_mower_for_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(lawn_mower, entry)
+    device = spec_device(Gen1Mower1, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], lawn_mower.GardenaMower)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_skips_non_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(lawn_mower, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(lawn_mower, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(lawn_mower, entry)
+    device = spec_device(Gen1Mower1, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+def test_gen1_mower_has_no_pause_feature(coordinator, spec_device) -> None:
+    device = spec_device(Gen1Mower1, device_id="device-1")
+    entity = lawn_mower.GardenaMower(coordinator, device)
+    assert not entity.supported_features & LawnMowerEntityFeature.PAUSE
+
+
+def test_gen2_mower_has_pause_feature(coordinator, spec_device) -> None:
+    device = spec_device(Gen2Mower, device_id="device-1")
+    entity = lawn_mower.GardenaMower(coordinator, device)
+    assert entity.supported_features & LawnMowerEntityFeature.PAUSE
+
+
+@pytest.mark.parametrize(
+    ("state", "expected"),
+    [
+        (MowerState.CHARGING, LawnMowerActivity.DOCKED),
+        (MowerState.PARKED, LawnMowerActivity.DOCKED),
+        (MowerState.LEAVING, LawnMowerActivity.MOWING),
+        (MowerState.MOWING, LawnMowerActivity.MOWING),
+        (MowerState.PAUSED, LawnMowerActivity.PAUSED),
+        (MowerState.RETURNING, LawnMowerActivity.RETURNING),
+        (MowerState.UNKNOWN, None),
+    ],
+)
+def test_activity_maps_mower_state(
+    coordinator, spec_device, sync_devices, state, expected
+) -> None:
+    device = spec_device(Gen1Mower1, device_id="device-1", state=state)
+    entity = lawn_mower.GardenaMower(coordinator, device)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    assert entity.activity == expected
+
+
+async def test_async_start_mowing(coordinator, spec_device) -> None:
+    device = spec_device(Gen1Mower1, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = lawn_mower.GardenaMower(coordinator, device)
+
+    await entity.async_start_mowing()
+
+    device.build_start_mowing_obj.assert_called_once_with(28800)
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_start_mowing_obj.return_value, wait_for_response_sec=10
+    )
+
+
+async def test_async_dock(coordinator, spec_device) -> None:
+    device = spec_device(Gen1Mower1, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = lawn_mower.GardenaMower(coordinator, device)
+
+    await entity.async_dock()
+
+    device.build_stop_mowing_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_stop_mowing_obj.return_value, wait_for_response_sec=10
+    )
+
+
+async def test_async_pause_on_gen2_device(coordinator, spec_device) -> None:
+    device = spec_device(Gen2Mower, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = lawn_mower.GardenaMower(coordinator, device)
+
+    await entity.async_pause()
+
+    device.build_pause_mowing_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_pause_mowing_obj.return_value, wait_for_response_sec=10
+    )
+
+
+async def test_async_pause_on_gen1_device_is_noop(coordinator, spec_device) -> None:
+    device = spec_device(Gen1Mower1, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = lawn_mower.GardenaMower(coordinator, device)
+
+    await entity.async_pause()
+
+    coordinator.send_request.assert_not_awaited()

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -1,0 +1,173 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local number entities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from gardena_smart_local_api.devices import Gen1WaterControl, PowerAdapter, Pump
+
+from custom_components.gardena_smart_local_preview import number
+
+
+async def test_setup_adds_button_config_time_for_water_control(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(number, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 2
+    assert isinstance(entities[0], number.GardenaButtonConfigTime)
+    assert isinstance(entities[1], number.GardenaValveDuration)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_adds_turn_on_pressure_for_pump(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(number, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], number.GardenaPumpTurnOnPressure)
+
+
+async def test_setup_skips_non_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(number, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(number, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(number, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# GardenaButtonConfigTime
+# ---------------------------------------------------------------------------
+
+
+def test_button_config_time_native_value_converts_seconds_to_minutes(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    device.get_button_config_time.return_value = 120
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = number.GardenaButtonConfigTime(coordinator, device, valve_id=0)
+    assert entity.native_value == 2
+    device.get_button_config_time.assert_called_with(0)
+
+
+def test_button_config_time_native_value_none_when_raw_none(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    device.get_button_config_time.return_value = None
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = number.GardenaButtonConfigTime(coordinator, device, valve_id=0)
+    assert entity.native_value is None
+
+
+def test_button_config_time_native_value_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    device.get_button_config_time.return_value = 120
+    sync_devices()
+    entity = number.GardenaButtonConfigTime(coordinator, device, valve_id=0)
+    assert entity.native_value is None
+
+
+async def test_button_config_time_set_native_value_converts_minutes_to_seconds(
+    coordinator, spec_device
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    coordinator.send_request = AsyncMock()
+    entity = number.GardenaButtonConfigTime(coordinator, device, valve_id=0)
+
+    await entity.async_set_native_value(5)
+
+    device.build_set_button_config_time_obj.assert_called_once_with(300, 0)
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_set_button_config_time_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GardenaPumpTurnOnPressure
+# ---------------------------------------------------------------------------
+
+
+def test_turn_on_pressure_native_value(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(Pump, device_id="device-1", turn_on_pressure=2.5)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = number.GardenaPumpTurnOnPressure(coordinator, device)
+    assert entity.native_value == 2.5
+
+
+def test_turn_on_pressure_native_value_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Pump, device_id="device-1", turn_on_pressure=2.5)
+    sync_devices()
+    entity = number.GardenaPumpTurnOnPressure(coordinator, device)
+    assert entity.native_value is None
+
+
+async def test_turn_on_pressure_set_native_value(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = number.GardenaPumpTurnOnPressure(coordinator, device)
+
+    await entity.async_set_native_value(3.2)
+
+    device.build_set_turn_on_pressure_obj.assert_called_once_with(3.2)
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_set_turn_on_pressure_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+# Dripping alert moved to select.py (GardenaPumpDrippingAlert as a select,
+# not a number) - see test_select.py. No equivalent coverage was added there
+# yet when this test suite was rebased; the old number-entity tests for it
+# were removed here since the class no longer exists in number.py.

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -1,0 +1,158 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local pump operating-mode select entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from gardena_smart_local_api.devices import PowerAdapter, Pump
+from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
+
+from custom_components.gardena_smart_local_preview import select
+
+
+async def test_setup_adds_select_for_pump(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(select, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 2
+    assert isinstance(entities[0], select.GardenaPumpOperatingModeSelect)
+    assert isinstance(entities[1], select.GardenaPumpDrippingAlert)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_skips_non_pump_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(select, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(select, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(select, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+def test_options_are_scheduled_and_automatic(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+    assert entity.options == ["scheduled", "automatic"]
+
+
+def test_current_option_scheduled(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Pump, device_id="device-1", operating_mode=PumpOperatingMode.SCHEDULED
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+    assert entity.current_option == "scheduled"
+
+
+def test_current_option_automatic(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Pump, device_id="device-1", operating_mode=PumpOperatingMode.AUTOMATIC
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+    assert entity.current_option == "automatic"
+
+
+def test_current_option_none_when_mode_none(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Pump, device_id="device-1", operating_mode=None)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+    assert entity.current_option is None
+
+
+def test_current_option_none_when_mode_unmapped(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Pump, device_id="device-1", operating_mode=object())
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+    assert entity.current_option is None
+
+
+def test_current_option_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Pump, device_id="device-1", operating_mode=PumpOperatingMode.SCHEDULED
+    )
+    sync_devices()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+    assert entity.current_option is None
+
+
+async def test_select_option_scheduled(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+
+    await entity.async_select_option("scheduled")
+
+    device.build_set_operating_mode_obj.assert_called_once_with(
+        PumpOperatingMode.SCHEDULED
+    )
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_set_operating_mode_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+async def test_select_option_automatic(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+
+    await entity.async_select_option("automatic")
+
+    device.build_set_operating_mode_obj.assert_called_once_with(
+        PumpOperatingMode.AUTOMATIC
+    )
+
+
+async def test_select_option_invalid_raises_key_error(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+
+    with pytest.raises(KeyError):
+        await entity.async_select_option("bogus")

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local sensor entities."""
+
+from __future__ import annotations
+
+import pytest
+from gardena_smart_local_api.devices import (
+    Gen1WaterControl,
+    Gen2IrrigationControl,
+    Pump,
+    PumpState,
+    Sensor1,
+)
+
+from custom_components.gardena_smart_local_preview import sensor
+
+
+def _identity(value):
+    return value
+
+
+# (entity class, spec class, device attr, raw value, cast applied by native_value)
+SENSOR_TABLE = [
+    (sensor.GardenaTemperatureSensor, Gen1WaterControl, "temperature", 21, float),
+    (sensor.GardenaBatterySensor, Gen1WaterControl, "battery_level", 55, float),
+    (
+        sensor.GardenaRfLinkQualitySensor,
+        Gen1WaterControl,
+        "rf_link_quality",
+        80,
+        _identity,
+    ),
+    (sensor.GardenaSoilMoistureSensor, Sensor1, "soil_moisture", 42, float),
+    (sensor.GardenaLightSensor, Sensor1, "light", 1000, float),
+    (sensor.GardenaPumpPressureSensor, Pump, "outlet_pressure", 1.5, _identity),
+    (sensor.GardenaPumpTemperatureSensor, Pump, "outlet_temperature", 18, float),
+    (sensor.GardenaPumpFlowRateSensor, Pump, "flow_rate", 120, float),
+    (sensor.GardenaPumpFlowTotalSensor, Pump, "flow_total", 5, float),
+    (sensor.GardenaPumpFlowSinceResetSensor, Pump, "flow_since_last_reset", 2, float),
+    (
+        sensor.GardenaPumpStateSensor,
+        Pump,
+        "pump_state",
+        PumpState.PUMP_IS_JUST_STARTING,
+        str,
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    ("entity_cls", "spec_cls", "attr", "raw", "cast"), SENSOR_TABLE
+)
+def test_native_value_normal(
+    coordinator, spec_device, sync_devices, entity_cls, spec_cls, attr, raw, cast
+) -> None:
+    device = spec_device(spec_cls, device_id="device-1", **{attr: raw})
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = entity_cls(coordinator, device)
+    assert entity.native_value == cast(raw)
+
+
+@pytest.mark.parametrize(
+    ("entity_cls", "spec_cls", "attr", "raw", "cast"), SENSOR_TABLE
+)
+def test_native_value_none_when_raw_none(
+    coordinator, spec_device, sync_devices, entity_cls, spec_cls, attr, raw, cast
+) -> None:
+    device = spec_device(spec_cls, device_id="device-1", **{attr: None})
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = entity_cls(coordinator, device)
+    assert entity.native_value is None
+
+
+@pytest.mark.parametrize(
+    ("entity_cls", "spec_cls", "attr", "raw", "cast"), SENSOR_TABLE
+)
+def test_native_value_none_when_device_missing(
+    coordinator, spec_device, sync_devices, entity_cls, spec_cls, attr, raw, cast
+) -> None:
+    device = spec_device(spec_cls, device_id="device-1", **{attr: raw})
+    sync_devices()
+    entity = entity_cls(coordinator, device)
+    assert entity.native_value is None
+
+
+# ---------------------------------------------------------------------------
+# Setup / dynamic-add fan-out
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_water_control_gets_five_sensors(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(sensor, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 5
+    assert {type(e) for e in entities} == {
+        sensor.GardenaTemperatureSensor,
+        sensor.GardenaBatterySensor,
+        sensor.GardenaRfLinkQualitySensor,
+        sensor.GardenaScheduleCountSensor,
+        sensor.GardenaFirmwareUpdateStateSensor,
+    }
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_sensor1_gets_six_sensors_in_one_call(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(sensor, entry)
+    device = spec_device(Sensor1, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 6
+    assert {type(e) for e in entities} == {
+        sensor.GardenaTemperatureSensor,
+        sensor.GardenaSoilMoistureSensor,
+        sensor.GardenaLightSensor,
+        sensor.GardenaBatterySensor,
+        sensor.GardenaRfLinkQualitySensor,
+        sensor.GardenaFirmwareUpdateStateSensor,
+    }
+
+
+async def test_setup_pump_gets_nine_sensors_in_one_call(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(sensor, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 9
+    assert {type(e) for e in entities} == {
+        sensor.GardenaRfLinkQualitySensor,
+        sensor.GardenaPumpPressureSensor,
+        sensor.GardenaPumpTemperatureSensor,
+        sensor.GardenaPumpFlowRateSensor,
+        sensor.GardenaPumpFlowTotalSensor,
+        sensor.GardenaPumpFlowSinceResetSensor,
+        sensor.GardenaPumpStateSensor,
+        sensor.GardenaScheduleCountSensor,
+        sensor.GardenaFirmwareUpdateStateSensor,
+    }
+
+
+async def test_setup_adds_only_firmware_sensor_for_device_matching_no_other_gates(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(sensor, entry)
+    device = spec_device(Gen2IrrigationControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], sensor.GardenaFirmwareUpdateStateSensor)
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(sensor, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(sensor, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -159,7 +159,7 @@ async def test_setup_pump_gets_nine_sensors_in_one_call(
     }
 
 
-async def test_setup_adds_only_firmware_sensor_for_device_matching_no_other_gates(
+async def test_setup_adds_firmware_and_rf_link_sensors_for_device_matching_no_other_gates(
     coordinator, entry, setup_platform, spec_device, sync_devices
 ) -> None:
     async_add_entities = await setup_platform(sensor, entry)
@@ -169,8 +169,9 @@ async def test_setup_adds_only_firmware_sensor_for_device_matching_no_other_gate
 
     async_add_entities.assert_called_once()
     (entities,), _ = async_add_entities.call_args
-    assert len(entities) == 1
-    assert isinstance(entities[0], sensor.GardenaFirmwareUpdateStateSensor)
+    assert len(entities) == 2
+    assert isinstance(entities[0], sensor.GardenaRfLinkQualitySensor)
+    assert isinstance(entities[1], sensor.GardenaFirmwareUpdateStateSensor)
 
 
 async def test_setup_noop_when_coordinator_data_empty(

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,194 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local switch entities."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from gardena_smart_local_api.devices import Gen1WaterControl, PowerAdapter, Pump
+
+from custom_components.gardena_smart_local_preview import switch
+
+
+async def test_setup_adds_power_switch_for_power_adapter(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(switch, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], switch.GardenaPowerSwitch)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_adds_pump_switch_for_pump(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(switch, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], switch.GardenaPumpSwitch)
+
+
+async def test_setup_skips_non_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(switch, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(switch, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(switch, entry)
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+def test_power_switch_device_class_outlet(coordinator, spec_device) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1")
+    entity = switch.GardenaPowerSwitch(coordinator, device)
+    assert entity.device_class == "outlet"
+
+
+def test_pump_switch_has_no_device_class(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    entity = switch.GardenaPumpSwitch(coordinator, device)
+    assert entity.device_class is None
+
+
+def test_power_switch_is_on_true(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1", is_output_enabled=True)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = switch.GardenaPowerSwitch(coordinator, device)
+    assert entity.is_on is True
+
+
+def test_power_switch_is_on_false(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1", is_output_enabled=False)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = switch.GardenaPowerSwitch(coordinator, device)
+    assert entity.is_on is False
+
+
+def test_power_switch_is_on_none_when_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1", is_output_enabled=True)
+    sync_devices()
+    entity = switch.GardenaPowerSwitch(coordinator, device)
+    assert entity.is_on is None
+
+
+def test_pump_switch_is_on_true(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(Pump, device_id="device-1", is_running=True)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = switch.GardenaPumpSwitch(coordinator, device)
+    assert entity.is_on is True
+
+
+def test_pump_switch_is_on_false(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(Pump, device_id="device-1", is_running=False)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = switch.GardenaPumpSwitch(coordinator, device)
+    assert entity.is_on is False
+
+
+def test_pump_switch_is_on_none_when_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Pump, device_id="device-1", is_running=True)
+    sync_devices()
+    entity = switch.GardenaPumpSwitch(coordinator, device)
+    assert entity.is_on is None
+
+
+async def test_power_switch_turn_on(coordinator, spec_device) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = switch.GardenaPowerSwitch(coordinator, device)
+
+    await entity.async_turn_on()
+
+    device.build_enable_output_obj.assert_called_once_with(
+        switch.DEFAULT_ON_DURATION_SECONDS
+    )
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_enable_output_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+async def test_power_switch_turn_off(coordinator, spec_device) -> None:
+    device = spec_device(PowerAdapter, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = switch.GardenaPowerSwitch(coordinator, device)
+
+    await entity.async_turn_off()
+
+    device.build_disable_output_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_disable_output_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+async def test_pump_switch_turn_on(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = switch.GardenaPumpSwitch(coordinator, device)
+
+    await entity.async_turn_on()
+
+    device.build_start_obj.assert_called_once_with(switch.DEFAULT_ON_DURATION_SECONDS)
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_start_obj.return_value, wait_for_response_sec=10
+    )
+
+
+async def test_pump_switch_turn_off(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = switch.GardenaPumpSwitch(coordinator, device)
+
+    await entity.async_turn_off()
+
+    device.build_stop_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_stop_obj.return_value, wait_for_response_sec=10
+    )

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,367 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local firmware update entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from gardena_smart_local_api.devices import Gen1WaterControl
+from gardena_smart_local_api.devices.device import FirmwareUpdateState
+
+from custom_components.gardena_smart_local_preview import update
+
+# ---------------------------------------------------------------------------
+# async_setup_entry
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_adds_update_entity_for_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(update, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], update.GardenaFirmwareUpdate)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(update, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(update, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# installed_version / latest_version
+# ---------------------------------------------------------------------------
+
+
+def test_installed_version_returns_software_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", software_version="1.0")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.installed_version == "1.0"
+
+
+def test_installed_version_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.installed_version is None
+
+
+def test_latest_version_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version is None
+
+
+def test_latest_version_downloaded_uses_available_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.DOWNLOADED,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "2.0"
+
+
+def test_latest_version_downloaded_falls_back_to_installed(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.DOWNLOADED,
+        available_software_version=None,
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "1.0"
+
+
+def test_latest_version_updating_uses_held_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity._held_latest_version = "1.9"
+    assert entity.latest_version == "1.9"
+
+
+def test_latest_version_updating_falls_back_to_available_then_installed(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "2.0"
+
+
+def test_latest_version_idle_returns_installed_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.IDLE,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "1.0"
+
+
+def test_latest_version_downloading_returns_installed_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.DOWNLOADING,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# _handle_coordinator_update: held target version while updating
+# ---------------------------------------------------------------------------
+
+
+def test_handle_coordinator_update_holds_version_on_entering_updating(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version == "2.0"
+
+
+def test_handle_coordinator_update_keeps_existing_held_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+    entity._held_latest_version = "1.9"
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version == "1.9"
+
+
+def test_handle_coordinator_update_clears_held_version_when_not_in_progress(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.IDLE,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+    entity._held_latest_version = "1.9"
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version is None
+
+
+def test_handle_coordinator_update_noop_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+    entity._held_latest_version = "1.9"
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version == "1.9"
+
+
+# ---------------------------------------------------------------------------
+# version_is_newer / in_progress
+# ---------------------------------------------------------------------------
+
+
+def test_version_is_newer_true_for_downgrade(coordinator, spec_device) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.version_is_newer("1.0", "2.0") is True
+
+
+def test_version_is_newer_false_when_equal(coordinator, spec_device) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.version_is_newer("1.0", "1.0") is False
+
+
+def test_in_progress_true_when_updating(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.in_progress is True
+
+
+def test_in_progress_false_when_idle(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.IDLE,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.in_progress is False
+
+
+def test_in_progress_false_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.in_progress is False
+
+
+# ---------------------------------------------------------------------------
+# async_install / async_added_to_hass
+# ---------------------------------------------------------------------------
+
+
+async def test_async_install_holds_version_and_sends_request(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl, device_id="device-1", available_software_version="2.0"
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    coordinator.send_request = AsyncMock()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+
+    await entity.async_install(version="2.0", backup=False)
+
+    assert entity._held_latest_version == "2.0"
+    device.build_install_firmware_update_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1",
+        device.build_install_firmware_update_obj.return_value,
+        wait_for_response_sec=10,
+    )
+
+
+async def test_async_install_noop_hold_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    coordinator.send_request = AsyncMock()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+
+    await entity.async_install(version="2.0", backup=False)
+
+    assert entity._held_latest_version is None
+    coordinator.send_request.assert_awaited_once()
+
+
+async def test_async_added_to_hass_refreshes_firmware(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    coordinator.async_refresh_firmware = AsyncMock()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.hass = coordinator.hass
+
+    await entity.async_added_to_hass()
+
+    coordinator.async_refresh_firmware.assert_awaited_once_with("device-1")

--- a/tests/test_valve.py
+++ b/tests/test_valve.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local valve entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from gardena_smart_local_api.devices import (
+    Gen1IrrigationControl,
+    Gen1WaterControl,
+    Pump,
+)
+
+from custom_components.gardena_smart_local_preview import valve
+
+
+async def test_setup_adds_single_valve_for_water_control(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(valve, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], valve.GardenaValve)
+    assert entities[0].name is None
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_adds_six_valves_for_irrigation_control(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(valve, entry)
+    device = spec_device(
+        Gen1IrrigationControl, device_id="device-1", valve_ids=list(range(6))
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), _ = async_add_entities.call_args
+    assert len(entities) == 6
+    for i, entity in enumerate(entities):
+        assert entity._attr_translation_key == "valve"
+        assert entity._attr_translation_placeholders == {"number": str(i + 1)}
+
+
+async def test_setup_skips_non_matching_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(valve, entry)
+    device = spec_device(Pump, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(valve, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(valve, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+def test_is_closed_true_when_valve_open(
+    coordinator, entry, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    device.is_valve_open.return_value = True
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = valve.GardenaValve(coordinator, entry, device, valve_id=0)
+    assert entity.is_closed is False
+
+
+def test_is_closed_true_when_valve_not_open(
+    coordinator, entry, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    device.is_valve_open.return_value = False
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = valve.GardenaValve(coordinator, entry, device, valve_id=0)
+    assert entity.is_closed is True
+
+
+def test_is_closed_none_when_valve_state_unknown(
+    coordinator, entry, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    device.is_valve_open.return_value = None
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = valve.GardenaValve(coordinator, entry, device, valve_id=0)
+    assert entity.is_closed is None
+
+
+def test_is_closed_none_when_device_missing(
+    coordinator, entry, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", valve_ids=[0])
+    sync_devices()
+    entity = valve.GardenaValve(coordinator, entry, device, valve_id=0)
+    assert entity.is_closed is None
+
+
+@pytest.mark.parametrize("valve_id", [0, 3])
+async def test_async_open_valve(coordinator, entry, spec_device, valve_id) -> None:
+    device = spec_device(
+        Gen1IrrigationControl, device_id="device-1", valve_ids=list(range(6))
+    )
+    coordinator.send_request = AsyncMock()
+    entity = valve.GardenaValve(coordinator, entry, device, valve_id=valve_id)
+
+    await entity.async_open_valve()
+
+    # No subentry configured for this device, so the default (30 min) applies.
+    device.build_open_valve_obj.assert_called_once_with(valve_id, 1800)
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_open_valve_obj.return_value, wait_for_response_sec=10
+    )
+
+
+@pytest.mark.parametrize("valve_id", [0, 3])
+async def test_async_close_valve(coordinator, entry, spec_device, valve_id) -> None:
+    device = spec_device(
+        Gen1IrrigationControl, device_id="device-1", valve_ids=list(range(6))
+    )
+    coordinator.send_request = AsyncMock()
+    entity = valve.GardenaValve(coordinator, entry, device, valve_id=valve_id)
+
+    await entity.async_close_valve()
+
+    device.build_close_valve_obj.assert_called_once_with(valve_id)
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_close_valve_obj.return_value, wait_for_response_sec=10
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -2095,6 +2095,7 @@ dev = [
     { name = "pytest-homeassistant-custom-component", version = "0.13.316", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and python_full_version < '3.14.2'" },
     { name = "pytest-homeassistant-custom-component", version = "0.13.345", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
     { name = "reuse" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -2104,6 +2105,7 @@ dev = [
     { name = "gardena-smart-local-api", specifier = "==0.1.3" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13" },
     { name = "reuse", specifier = ">=6.2.0" },
+    { name = "ty", specifier = ">=0.0.59" },
 ]
 
 [[package]]
@@ -5242,6 +5244,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.59"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Bronze
- [x] `action-setup` - Service actions are registered in async_setup
- [x] `appropriate-polling` - If it's a polling integration, set an appropriate polling interval
- [ ] `brands` - Has branding assets available for the integration (home-assistant/brands#10811 still open)
- [x] `common-modules` - Place common patterns in common modules
- [x] `config-flow-test-coverage` - Full test coverage for the config flow
- [x] `config-flow` - Integration needs to be able to be set up via the UI
    - [x] Uses `data_description` to give context to fields
    - [x] Uses `ConfigEntry.data` and `ConfigEntry.options` correctly
- [x] `dependency-transparency` - Dependency transparency
- [x] `docs-actions` - The documentation describes the provided service actions that can be used (N/A - no custom actions)
- [x] `docs-triggers` - The documentation describes the provided triggers that can be used (N/A - no custom triggers)
- [x] `docs-conditions` - The documentation describes the provided conditions that can be used (N/A - no custom conditions)
- [x] `docs-high-level-description` - The documentation includes a high-level description of the integration brand, product, or service
- [x] `docs-installation-instructions` - The documentation provides step-by-step installation instructions for the integration, including, if needed, prerequisites
- [x] `docs-removal-instructions` - The documentation provides removal instructions
- [x] `entity-event-setup` - Entity events are subscribed in the correct lifecycle methods
- [x] `entity-unique-id` - Entities have a unique ID
- [x] `has-entity-name` - Entities use has_entity_name = True
- [x] `runtime-data` - Use ConfigEntry.runtime_data to store runtime data
- [x] `test-before-configure` - Test a connection in the config flow
- [x] `test-before-setup` - Check during integration initialization if we are able to set it up correctly
- [x] `unique-config-entry` - Don't allow the same device or service to be able to be set up twice

## Silver
- [x] `action-exceptions` - Service actions raise exceptions when encountering failures
- [x] `config-entry-unloading` - Support config entry unloading
- [x] `docs-configuration-parameters` - The documentation describes all integration configuration options
- [x] `docs-installation-parameters` - The documentation describes all integration installation parameters
- [x] `entity-unavailable` - Mark entity unavailable if appropriate
- [x] `integration-owner` - Has an integration owner
- [ ] `log-when-unavailable` - Per-device transitions log once, but the websocket reconnect loop logs on every 5 s retry
- [x] `parallel-updates` - Number of parallel updates is specified
- [ ] `reauthentication-flow` - Reauthentication needs to be available via the UI
- [ ] `test-coverage` - Above 95% test coverage for all integration modules

## Gold
- [x] `devices` - The integration creates devices
- [x] `diagnostics` - Implements diagnostics
- [ ] `discovery-update-info` - Integration uses discovery info to update network information
- [x] `discovery` - Devices can be discovered
- [x] `docs-data-update` - The documentation describes how data is updated
- [ ] `docs-examples` - The documentation provides automation examples the user can use.
- [ ] `docs-known-limitations` - The documentation describes known limitations of the integration (not to be confused with bugs)
- [x] `docs-supported-devices` - The documentation describes known supported / unsupported devices
- [x] `docs-supported-functions` - The documentation describes the supported functionality, including entities, and platforms
- [ ] `docs-troubleshooting` - The documentation provides troubleshooting information
- [ ] `docs-use-cases` - The documentation describes use cases to illustrate how this integration can be used
- [x] `dynamic-devices` - Devices added after integration setup
- [x] `entity-category` - Entities are assigned an appropriate EntityCategory
- [x] `entity-device-class` - Entities use device classes where possible
- [x] `entity-disabled-by-default` - Integration disables less popular (or noisy) entities
- [ ] `entity-translations` - Entities have translated names
- [ ] `exception-translations` - Exception messages are translatable
- [ ] `icon-translations` - Entities implement icon translations
- [x] `reconfiguration-flow` - Integrations should have a reconfigure flow
- [ ] `repair-issues` - Repair issues and repair flows are used when user intervention is needed
- [ ] `stale-devices` - Stale devices are removed

## Platinum
- [x] `async-dependency` - Dependency is async
- [x] `inject-websession` - The integration dependency supports passing in a websession
- [ ] `strict-typing` - Strict typing

