### PR TITLE
Add reauthentication flow

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -4,6 +4,8 @@
 
 import base64
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 import aiohttp
 import voluptuous as vol
@@ -153,6 +155,37 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
                     ): str,
                 }
             ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            error = await _async_try_connect(
+                self.hass,
+                entry.data[CONF_HOST],
+                entry.data[CONF_PORT],
+                user_input[CONF_PASSWORD],
+            )
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(
+                    entry, data={**entry.data, CONF_PASSWORD: user_input[CONF_PASSWORD]}
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD, default=""): str}),
             errors=errors,
         )
 

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -136,6 +136,18 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             except asyncio.CancelledError:
                 _LOGGER.debug("WebSocket loop cancelled")
                 break
+            except aiohttp.WSServerHandshakeError as err:
+                if err.status == 401:
+                    _LOGGER.error(
+                        "Authentication failed connecting to GARDENA smart Gateway "
+                        "at %s",
+                        self.uri,
+                    )
+                    if self.config_entry:
+                        self.config_entry.async_start_reauth(self.hass)
+                    break
+                _LOGGER.error("WebSocket error: %s", err)
+                await asyncio.sleep(5)
             except Exception as err:
                 _LOGGER.error("WebSocket error: %s", err)
                 await asyncio.sleep(5)

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -76,6 +76,16 @@
           "host": "IP-Adresse oder Hostname des GARDENA smart Gateways",
           "password": "Erster Block der Gateway-ID auf der Rückseite des Geräts (z. B. `0824b95b` aus `0824b95b-996c-48f7-83dc-…`)."
         }
+      },
+      "reauth_confirm": {
+        "title": "GARDENA smart Gateway erneut authentifizieren",
+        "description": "Das Passwort für dein GARDENA smart Gateway ist nicht mehr gültig. Gib das aktuelle Passwort ein, um die Verbindung wiederherzustellen.",
+        "data": {
+          "password": "Passwort"
+        },
+        "data_description": {
+          "password": "Erster Block der Gateway-ID auf der Rückseite des Geräts (z. B. `0824b95b` aus `0824b95b-996c-48f7-83dc-…`)."
+        }
       }
     },
     "error": {
@@ -86,7 +96,8 @@
     "abort": {
       "already_configured": "Gateway ist bereits konfiguriert",
       "already_in_progress": "Das Gateway wurde anscheinend automatisch erkannt, klicke stattdessen auf \"Hinzufügen\" bei der erkannten Integration",
-      "reconfigure_successful": "GARDENA smart Gateway-Einstellungen aktualisiert"
+      "reconfigure_successful": "GARDENA smart Gateway-Einstellungen aktualisiert",
+      "reauth_successful": "Erneute Authentifizierung erfolgreich"
     }
   }
 }

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -76,6 +76,16 @@
           "host": "IP address or hostname of your GARDENA smart Gateway",
           "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate GARDENA smart Gateway",
+        "description": "The password for your GARDENA smart Gateway is no longer valid. Enter the current password to reconnect.",
+        "data": {
+          "password": "Password"
+        },
+        "data_description": {
+          "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
+        }
       }
     },
     "error": {
@@ -86,7 +96,8 @@
     "abort": {
       "already_configured": "Gateway is already configured",
       "already_in_progress": "It seems the gateway has been autodetected, click \"Add\" on discovered integration instead",
-      "reconfigure_successful": "GARDENA smart Gateway settings updated"
+      "reconfigure_successful": "GARDENA smart Gateway settings updated",
+      "reauth_successful": "Re-authentication was successful"
     }
   }
 }


### PR DESCRIPTION
Wrong/changed gateway password left the websocket loop retrying forever with no way for the user to fix it from the UI. Detect 401 on connect and trigger HA's reauth flow instead.

Needed for silver level