### PR TITLE
Add PARALLEL_UPDATES to all platforms

### DIFF
--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -20,6 +20,10 @@ from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
 
+# State comes only from the coordinator's push (no polling, no actions) —
+# there is nothing here for PARALLEL_UPDATES to throttle
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -19,6 +19,10 @@ from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 
+# Actions send commands to the gateway's local websocket — cap at 1 so HA
+# serializes them instead of firing concurrent commands at the same connection
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -24,6 +24,10 @@ from .entity import GardenaEntity, find_device_subentry_id
 
 _LOGGER = logging.getLogger(__name__)
 
+# Actions send commands to the gateway's local websocket — cap at 1 so HA
+# serializes them instead of firing concurrent commands at the same connection
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -19,6 +19,10 @@ from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 
+# Actions send commands to the gateway's local websocket — cap at 1 so HA
+# serializes them instead of firing concurrent commands at the same connection
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -18,6 +18,10 @@ from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
 
 _LOGGER = logging.getLogger(__name__)
 
+# Actions send commands to the gateway's local websocket — cap at 1 so HA
+# serializes them instead of firing concurrent commands at the same connection
+PARALLEL_UPDATES = 1
+
 _MODE_TO_OPTION: dict[PumpOperatingMode, str] = {
     PumpOperatingMode.SCHEDULED: "scheduled",
     PumpOperatingMode.AUTOMATIC: "automatic",

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -31,6 +31,10 @@ from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 
+# State comes only from the coordinator's push (no polling, no actions) —
+# there is nothing here for PARALLEL_UPDATES to throttle
+PARALLEL_UPDATES = 0
+
 
 async def async_setup_entry(
     hass: HomeAssistant,

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -18,6 +18,10 @@ from gardena_smart_local_api.devices import PowerAdapter, Pump
 
 _LOGGER = logging.getLogger(__name__)
 
+# Actions send commands to the gateway's local websocket — cap at 1 so HA
+# serializes them instead of firing concurrent commands at the same connection
+PARALLEL_UPDATES = 1
+
 # used as "indefinitly" in the official app
 DEFAULT_ON_DURATION_SECONDS = 16777216
 

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -18,6 +18,10 @@ from gardena_smart_local_api.devices import Device
 
 _LOGGER = logging.getLogger(__name__)
 
+# Actions send commands to the gateway's local websocket — cap at 1 so HA
+# serializes them instead of firing concurrent commands at the same connection
+PARALLEL_UPDATES = 1
+
 
 async def async_setup_entry(
     hass: HomeAssistant,


### PR DESCRIPTION
## Summary
- Set `PARALLEL_UPDATES` on all platforms. Action platforms serialize (single shared websocket to gateway); read-only platforms allow unlimited parallelism.

Required for HA silver quality scale.