### PR TITLE
Support button time config for Gen2 water/irrigation controls

### DIFF
--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
-  "requirements": ["gardena-smart-local-api==0.1.0"],
+  "requirements": ["gardena-smart-local-api==0.1.1"],
   "version": "0.1.0",
   "zeroconf": ["_gardena-smart._tcp.local."]
 }

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -96,9 +96,10 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         multi_valve = len(device.valve_ids) > 1
         suffix = f"_{valve_id}" if multi_valve else ""
         self._attr_unique_id = f"{device.id}_button_config_time{suffix}"
-        self._attr_name = (
-            f"Button Time {valve_id + 1}" if multi_valve else "Button Time"
-        )
+        if multi_valve:
+            self._attr_name = f"Button Watering Duration {valve_id + 1}"
+        else:
+            self._attr_name = "Button Watering Duration"
         self._attr_icon = "mdi:timer-outline"
 
     @property

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -31,25 +31,35 @@ async def async_setup_entry(
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
+    known_button_time_valves: set[tuple[str, int]] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
         known_devices.intersection_update(coordinator.data)
+        known_button_time_valves.intersection_update(
+            (device.id, valve_id)
+            for device in coordinator.data.values()
+            if hasattr(device, "build_set_button_config_time_obj")
+            for valve_id in device.valve_ids
+        )
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
-            if (
-                hasattr(device, "build_set_button_config_time_obj")
-                and device.id not in known_devices
-            ):
-                known_devices.add(device.id)
+            if hasattr(device, "build_set_button_config_time_obj"):
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).append(
-                    GardenaButtonConfigTime(coordinator, device)
-                )
-                _LOGGER.info(
-                    "Adding new button config time entity for device %s", device.id
-                )
+                for valve_id in device.valve_ids:
+                    key = (device.id, valve_id)
+                    if key in known_button_time_valves:
+                        continue
+                    known_button_time_valves.add(key)
+                    entities_by_subentry_id.setdefault(sid, []).append(
+                        GardenaButtonConfigTime(coordinator, device, valve_id)
+                    )
+                    _LOGGER.info(
+                        "Adding new button config time entity for device %s, valve %s",
+                        device.id,
+                        valve_id,
+                    )
             elif isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
@@ -79,10 +89,16 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         self,
         coordinator: GardenaSmartLocalCoordinator,
         device: Device,
+        valve_id: int = 0,
     ) -> None:
         super().__init__(coordinator, device)
-        self._attr_unique_id = f"{device.id}_button_config_time"
-        self._attr_name = "Button Time"
+        self._valve_id = valve_id
+        multi_valve = len(device.valve_ids) > 1
+        suffix = f"_{valve_id}" if multi_valve else ""
+        self._attr_unique_id = f"{device.id}_button_config_time{suffix}"
+        self._attr_name = (
+            f"Button Time {valve_id + 1}" if multi_valve else "Button Time"
+        )
         self._attr_icon = "mdi:timer-outline"
 
     @property
@@ -90,16 +106,23 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         device = self.coordinator.data.get(self._device.id)
         if not device:
             return None
-        seconds = device.button_config_time
+        if hasattr(device, "get_button_config_time"):
+            seconds = device.get_button_config_time(self._valve_id)
+        else:
+            seconds = device.button_config_time
         if seconds is None:
             return None
         return round(seconds / 60)
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_set_button_config_time_obj(int(value) * 60),
-        )
+        seconds = int(value) * 60
+        if hasattr(self._device, "get_button_config_time"):
+            request = self._device.build_set_button_config_time_obj(
+                seconds, self._valve_id
+            )
+        else:
+            request = self._device.build_set_button_config_time_obj(seconds)
+        await self.coordinator.send_request(self._device.id, request)
         _LOGGER.info(
             "Set button config time for device %s to %s minutes",
             self._device.id,


### PR DESCRIPTION
Gen2 devices expose button time per valve, so the number entity now creates one entity per valve and dispatches to the matching lib API.

<img width="404" height="207" alt="image" src="https://github.com/user-attachments/assets/18162825-b2b6-493b-8e28-c6179de9e4a4" />
