### PR TITLE
Fix bugs found by Copilot review on the core port

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,15 @@ jobs:
         with:
           args: format --check
 
+  ty:
+    name: ty
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --group dev
+      - run: uv run ty check custom_components
+
   hassfest:
     name: Hassfest
     runs-on: ubuntu-latest

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -153,6 +153,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register before platform listeners so subentries exist when
     # platforms look them up for newly discovered devices.
     entry.async_on_unload(coordinator.async_add_listener(_ensure_device_subentries))
+    _ensure_device_subentries()
 
     known_subentries: dict[str, str] = {
         sid: se.data["device_id"]

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -5,6 +5,7 @@
 import logging
 from types import MappingProxyType
 
+import aiohttp
 import voluptuous as vol
 
 
@@ -16,6 +17,7 @@ from homeassistant.config_entries import (
     SOURCE_IMPORT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.const import (
@@ -84,7 +86,22 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         port=entry.data[CONF_PORT],
         password=entry.data[CONF_PASSWORD],
     )
-    await coordinator.async_connect()
+    try:
+        await coordinator.async_connect()
+    except aiohttp.WSServerHandshakeError as err:
+        await coordinator.async_disconnect()
+        if err.status == 401:
+            raise ConfigEntryAuthFailed(
+                f"Invalid password for GARDENA smart Gateway at {coordinator.uri}"
+            ) from err
+        raise ConfigEntryNotReady(
+            f"Could not connect to GARDENA smart Gateway at {coordinator.uri}"
+        ) from err
+    except Exception as err:
+        await coordinator.async_disconnect()
+        raise ConfigEntryNotReady(
+            f"Could not connect to GARDENA smart Gateway at {coordinator.uri}"
+        ) from err
     entry.runtime_data = coordinator
 
     async def _stop(_event: object) -> None:

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -191,6 +191,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    if not await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        return False
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     await coordinator.async_disconnect()
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    return True

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -54,7 +54,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaFrostWarningSensor(GardenaEntity, BinarySensorEntity):

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -83,7 +83,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaIdentifyButton(GardenaEntity, ButtonEntity):

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Protocol, cast
 
 from homeassistant.components.button import ButtonEntity
 from homeassistant.const import EntityCategory
@@ -16,12 +17,21 @@ from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
 from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.messages import EgressMessageList
 
 _LOGGER = logging.getLogger(__name__)
 
 # Actions send commands to the gateway's local websocket — cap at 1 so HA
 # serializes them instead of firing concurrent commands at the same connection
 PARALLEL_UPDATES = 1
+
+
+class _Identifiable(Protocol):
+    def build_identify_obj(self) -> EgressMessageList: ...
+
+
+class _ScheduleClearable(Protocol):
+    def build_clear_schedules_obj(self) -> EgressMessageList: ...
 
 
 async def async_setup_entry(
@@ -89,7 +99,7 @@ class GardenaIdentifyButton(GardenaEntity, ButtonEntity):
     async def async_press(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_identify_obj(),
+            cast(_Identifiable, self._device).build_identify_obj(),
         )
         _LOGGER.info("Sent identify request for device %s", self._device.id)
 
@@ -104,7 +114,7 @@ class GardenaPumpResetFlowButton(GardenaEntity, ButtonEntity):
     async def async_press(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_reset_flow_resettable_obj(),
+            cast(Pump, self._device).build_reset_flow_resettable_obj(),
         )
         _LOGGER.info("Reset resettable flow for device %s", self._device.id)
 
@@ -119,7 +129,7 @@ class GardenaPumpResetValveErrorsButton(GardenaEntity, ButtonEntity):
     async def async_press(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_reset_all_valve_errors_obj(),
+            cast(Pump, self._device).build_reset_all_valve_errors_obj(),
         )
         _LOGGER.info("Reset valve errors for device %s", self._device.id)
 
@@ -134,7 +144,7 @@ class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
     async def async_press(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_reset_outlet_temperature_min_max_obj(),
+            cast(Pump, self._device).build_reset_outlet_temperature_min_max_obj(),
         )
         _LOGGER.info("Reset temperature min/max for device %s", self._device.id)
 
@@ -155,6 +165,6 @@ class GardenaClearSchedulesButton(GardenaEntity, ButtonEntity):
     async def async_press(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_clear_schedules_obj(),
+            cast(_ScheduleClearable, self._device).build_clear_schedules_obj(),
         )
         _LOGGER.info("Cleared schedules for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -49,6 +49,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            # A zeroconf-discovered entry for the same host would have a
+            # different (mDNS name based) unique_id, so also match on host.
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             await self.async_set_unique_id(user_input[CONF_HOST])
             self._abort_if_unique_id_configured()
 
@@ -85,6 +88,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         host = discovery_info.host
         port = discovery_info.port or DEFAULT_PORT
 
+        # A manually-added entry for the same host would have a different
+        # (host based) unique_id, so also match on host.
+        self._async_abort_entries_match({CONF_HOST: host})
         await self.async_set_unique_id(name)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host, CONF_PORT: port})
 

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -4,6 +4,8 @@
 
 import base64
 import logging
+from collections.abc import Mapping
+from typing import Any
 
 import aiohttp
 import voluptuous as vol
@@ -157,6 +159,37 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
                     ): str,
                 }
             ),
+            errors=errors,
+        )
+
+    async def async_step_reauth(
+        self, entry_data: Mapping[str, Any]
+    ) -> ConfigFlowResult:
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(
+        self, user_input: dict | None = None
+    ) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        entry = self._get_reauth_entry()
+
+        if user_input is not None:
+            error = await _async_try_connect(
+                self.hass,
+                entry.data[CONF_HOST],
+                entry.data[CONF_PORT],
+                user_input[CONF_PASSWORD],
+            )
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(
+                    entry, data={**entry.data, CONF_PASSWORD: user_input[CONF_PASSWORD]}
+                )
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PASSWORD, default=""): str}),
             errors=errors,
         )
 

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -9,6 +9,7 @@ from typing import Any
 
 import aiohttp
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -209,7 +210,7 @@ async def _async_try_connect(
     try:
         session = async_get_clientsession(hass)
         async with session.ws_connect(
-            f"wss://{host}:{port}",
+            URL.build(scheme="wss", host=host, port=port),
             ssl=ssl_context,
             headers={"Authorization": f"Basic {auth_b64}"},
             # ty doesn't resolve aiohttp's legacy attr.ib()-based __init__.

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -179,7 +179,8 @@ async def _async_try_connect(
             f"wss://{host}:{port}",
             ssl=ssl_context,
             headers={"Authorization": f"Basic {auth_b64}"},
-            timeout=aiohttp.ClientTimeout(total=10),
+            # ty doesn't resolve aiohttp's legacy attr.ib()-based __init__.
+            timeout=aiohttp.ClientWSTimeout(ws_receive=10),  # ty: ignore[unknown-argument]
         ) as ws:
             await ws.close()
     except aiohttp.WSServerHandshakeError as err:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -137,6 +137,18 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             except asyncio.CancelledError:
                 _LOGGER.debug("WebSocket loop cancelled")
                 break
+            except aiohttp.WSServerHandshakeError as err:
+                if err.status == 401:
+                    _LOGGER.error(
+                        "Authentication failed connecting to GARDENA smart Gateway "
+                        "at %s",
+                        self.uri,
+                    )
+                    if self.config_entry:
+                        self.config_entry.async_start_reauth(self.hass)
+                    break
+                _LOGGER.error("WebSocket error: %s", err)
+                await asyncio.sleep(5)
             except Exception as err:
                 _LOGGER.error("WebSocket error: %s", err)
                 await asyncio.sleep(5)

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
+from yarl import URL
 
 from gardena_smart_local_api.devices import (
     Device,
@@ -63,7 +64,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self.host = host
         self.port = port
         self.password = password
-        self.uri = f"wss://{host}:{port}"
+        self.uri = URL.build(scheme="wss", host=host, port=port)
 
         auth_string = f"_:{password}"
         auth_bytes = auth_string.encode("utf-8")

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -514,6 +514,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
     def _update_devices(self, devices: DeviceMap) -> None:
         try:
+            for device_id in self._devices.keys() - devices.keys():
+                _LOGGER.info(
+                    "Device %s no longer present in discovery, dropping", device_id
+                )
+                del self._devices[device_id]
             for device in devices.values():
                 self._update_device(device)
         except Exception as err:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 import aiohttp
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
@@ -509,10 +510,9 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         wait_for_response_sec: float = 0,
     ) -> IngressMessageList:
         if not self._ws or self._ws.closed:
-            _LOGGER.error(
-                "Cannot send request to device %s: WebSocket not connected", device_id
+            raise HomeAssistantError(
+                f"Cannot send request to device {device_id}: WebSocket not connected"
             )
-            return IngressMessageList([])
 
         if wait_for_response_sec > 0:
             loop = asyncio.get_running_loop()

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -79,16 +79,21 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self._pending_replies: dict[str, asyncio.Future[Reply]] = {}
         self._includable_devices: dict[str, IncludableDeviceInfo] = {}
         self._includable_timeouts: dict[str, asyncio.TimerHandle] = {}
+        self._first_connect_result: asyncio.Future[None] | None = None
 
     async def _async_update_data(self) -> DeviceMap:
         return self._devices
 
     async def async_connect(self) -> None:
+        """Connect to the gateway, waiting for the first attempt to succeed."""
         if self._ssl_context is None:
             self._ssl_context = get_default_no_verify_context()
+        self._first_connect_result = self.hass.loop.create_future()
         self._task = self.hass.async_create_background_task(
             self._ws_loop(), "gardena_smart_local_preview_websocket"
         )
+        async with asyncio.timeout(15):
+            await self._first_connect_result
 
     async def async_disconnect(self) -> None:
         for handle in self._includable_timeouts.values():
@@ -129,6 +134,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     )
 
                     await self._do_discovery()
+                    if (
+                        self._first_connect_result
+                        and not self._first_connect_result.done()
+                    ):
+                        self._first_connect_result.set_result(None)
 
                     # Block until either worker exits (disconnect / error), then
                     # re-raise its exception, if any, so we reconnect below.
@@ -144,8 +154,12 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
             except asyncio.CancelledError:
                 _LOGGER.debug("WebSocket loop cancelled")
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.cancel()
                 break
             except aiohttp.WSServerHandshakeError as err:
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.set_exception(err)
                 if err.status == 401:
                     _LOGGER.error(
                         "Authentication failed connecting to GARDENA smart Gateway "
@@ -158,6 +172,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 _LOGGER.error("WebSocket error: %s", err)
                 await asyncio.sleep(5)
             except Exception as err:
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.set_exception(err)
                 _LOGGER.error("WebSocket error: %s", err)
                 await asyncio.sleep(5)
             finally:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -105,6 +105,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             consumer_task = None
             try:
                 _LOGGER.debug("Connecting to GARDENA smart Gateway at %s", self.uri)
+                # Always set by async_connect() before this task starts.
+                assert self._ssl_context is not None
                 session = async_get_clientsession(self.hass)
                 async with session.ws_connect(
                     self.uri,

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -95,6 +95,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         async with asyncio.timeout(15):
             await self._first_connect_result
 
+    @property
+    def connected(self) -> bool:
+        """Return True if the WebSocket to the gateway is currently connected."""
+        return self._ws is not None and not self._ws.closed
+
     async def async_disconnect(self) -> None:
         for handle in self._includable_timeouts.values():
             handle.cancel()
@@ -190,6 +195,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     if not fut.done():
                         fut.cancel()
                 self._pending_replies.clear()
+                # Let entities re-check availability now that we're disconnected.
+                self.async_update_listeners()
 
     async def _ws_reader(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         async for msg in ws:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -129,8 +129,14 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
                     await self._do_discovery()
 
-                    # Block until the reader exits (disconnect / error)
-                    await reader_task
+                    # Block until either worker exits (disconnect / error), then
+                    # re-raise its exception, if any, so we reconnect below.
+                    done, _pending = await asyncio.wait(
+                        (reader_task, consumer_task),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for task in done:
+                        task.result()
                     _LOGGER.info(
                         "Disconnected from GARDENA smart Gateway, reconnecting"
                     )

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -48,6 +48,8 @@ class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):
 
     @property
     def available(self) -> bool:
+        if not self.coordinator.connected:
+            return False
         device = self.coordinator.data.get(self._device.id)
         return bool(device and device.is_online)
 

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -65,7 +65,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaMower(GardenaEntity, LawnMowerEntity):

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -86,8 +86,11 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
             self._attr_supported_features |= LawnMowerEntityFeature.PAUSE
 
     @property
-    def activity(self) -> LawnMowerActivity:
-        mower_state = cast(_Mower, self._device).state
+    def activity(self) -> LawnMowerActivity | None:
+        device = self.coordinator.data.get(self._device.id)
+        if device is None:
+            return None
+        mower_state = cast(_Mower, device).state
         _LOGGER.debug("Mower status: %s", mower_state)
         match mower_state:
             case MowerState.CHARGING | MowerState.PARKED:
@@ -102,7 +105,11 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
             case MowerState.RETURNING:
                 return LawnMowerActivity.RETURNING
 
-        return LawnMowerActivity.ERROR
+            case MowerState.ERROR:
+                return LawnMowerActivity.ERROR
+
+        # MowerState.UNKNOWN or any state the dependency doesn't map yet.
+        return None
 
     async def async_start_mowing(self) -> None:
         await self.coordinator.send_request(

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -7,8 +7,15 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
-from gardena_smart_local_api.devices import Device, MowerState
+from gardena_smart_local_api.devices import (
+    Device,
+    Gen1Mower1,
+    Gen1Mower2,
+    Gen2Mower,
+    MowerState,
+)
 
 from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
@@ -27,6 +34,8 @@ _LOGGER = logging.getLogger(__name__)
 # Actions send commands to the gateway's local websocket — cap at 1 so HA
 # serializes them instead of firing concurrent commands at the same connection
 PARALLEL_UPDATES = 1
+
+_Mower = Gen1Mower1 | Gen1Mower2 | Gen2Mower
 
 
 async def async_setup_entry(
@@ -77,7 +86,7 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
 
     @property
     def activity(self) -> LawnMowerActivity:
-        mower_state = self._device.state
+        mower_state = cast(_Mower, self._device).state
         _LOGGER.debug("Mower status: %s", mower_state)
         match mower_state:
             case MowerState.CHARGING | MowerState.PARKED:
@@ -97,14 +106,14 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
     async def async_start_mowing(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_start_mowing_obj(28800),  # 8 hours
+            cast(_Mower, self._device).build_start_mowing_obj(28800),  # 8 hours
         )
         _LOGGER.info("Start mowing with %s", self._device.id)
 
     async def async_dock(self) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_stop_mowing_obj(),
+            cast(_Mower, self._device).build_stop_mowing_obj(),
         )
         _LOGGER.info("Stop mowing with %s", self._device.id)
 
@@ -112,7 +121,7 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
         if hasattr(self._device, "build_pause_mowing_obj"):
             await self.coordinator.send_request(
                 self._device.id,
-                self._device.build_pause_mowing_obj(),
+                cast(Gen2Mower, self._device).build_pause_mowing_obj(),
             )
             _LOGGER.info("Pause mowing with %s", self._device.id)
         else:

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -64,7 +64,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaButtonConfigTime(GardenaEntity, NumberEntity):

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -54,13 +54,10 @@ async def async_setup_entry(
             elif isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).extend(
-                    [
-                        GardenaPumpTurnOnPressure(coordinator, device),
-                        GardenaPumpDrippingAlert(coordinator, device),
-                    ]
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPumpTurnOnPressure(coordinator, device)
                 )
-                _LOGGER.info("Adding new pump number entities for device %s", device.id)
+                _LOGGER.info("Adding new pump number entity for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -143,40 +140,4 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
             "Set turn-on pressure for device %s to %s bar",
             self._device.id,
             value,
-        )
-
-
-class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
-    _attr_native_min_value = 0
-    _attr_native_max_value = 3600
-    _attr_native_step = 1
-    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
-    _attr_mode = NumberMode.BOX
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def __init__(
-        self,
-        coordinator: GardenaSmartLocalCoordinator,
-        device: Pump,
-    ) -> None:
-        super().__init__(coordinator, device)
-        self._attr_unique_id = f"{device.id}_dripping_alert"
-        self._attr_name = "Dripping Alert Timeout"
-
-    @property
-    def native_value(self) -> float | None:
-        device = self.coordinator.data.get(self._device.id)
-        if not device:
-            return None
-        return device.dripping_alert
-
-    async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            cast(Pump, self._device).build_set_dripping_alert_obj(int(value)),
-        )
-        _LOGGER.info(
-            "Set dripping alert timeout for device %s to %s seconds",
-            self._device.id,
-            int(value),
         )

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -15,7 +16,7 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices.device import Device
-from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices import Gen1WaterControl, Pump
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -97,7 +98,9 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_set_button_config_time_obj(int(value) * 60),
+            cast(Gen1WaterControl, self._device).build_set_button_config_time_obj(
+                int(value) * 60
+            ),
         )
         _LOGGER.info(
             "Set button config time for device %s to %s minutes",
@@ -133,7 +136,7 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_set_turn_on_pressure_obj(value),
+            cast(Pump, self._device).build_set_turn_on_pressure_obj(value),
         )
         _LOGGER.info(
             "Set turn-on pressure for device %s to %s bar",
@@ -169,7 +172,7 @@ class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_set_dripping_alert_obj(int(value)),
+            cast(Pump, self._device).build_set_dripping_alert_obj(int(value)),
         )
         _LOGGER.info(
             "Set dripping alert timeout for device %s to %s seconds",

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -56,7 +56,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import cast
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
@@ -82,6 +83,6 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
         mode = _OPTION_TO_MODE[option]
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_set_operating_mode_obj(mode),
+            cast(Pump, self._device).build_set_operating_mode_obj(mode),
         )
         _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -9,13 +9,17 @@ from typing import cast
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import Pump
-from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
+from gardena_smart_local_api.devices.irrigation import (
+    PumpDrippingAlert,
+    PumpOperatingMode,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -29,6 +33,15 @@ _MODE_TO_OPTION: dict[PumpOperatingMode, str] = {
 }
 _OPTION_TO_MODE: dict[str, PumpOperatingMode] = {
     v: k for k, v in _MODE_TO_OPTION.items()
+}
+
+_DRIPPING_ALERT_TO_OPTION: dict[PumpDrippingAlert, str] = {
+    PumpDrippingAlert.MINUTES_60: "60_minutes",
+    PumpDrippingAlert.MINUTES_2: "2_minutes",
+    PumpDrippingAlert.DRIPPING_ALERT_OFF: "off",
+}
+_OPTION_TO_DRIPPING_ALERT: dict[str, PumpDrippingAlert] = {
+    v: k for k, v in _DRIPPING_ALERT_TO_OPTION.items()
 }
 
 
@@ -49,10 +62,13 @@ async def async_setup_entry(
             if isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).append(
-                    GardenaPumpOperatingModeSelect(coordinator, device)
+                entities_by_subentry_id.setdefault(sid, []).extend(
+                    [
+                        GardenaPumpOperatingModeSelect(coordinator, device),
+                        GardenaPumpDrippingAlert(coordinator, device),
+                    ]
                 )
-                _LOGGER.info("Adding operating mode select for device %s", device.id)
+                _LOGGER.info("Adding pump select entities for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -87,3 +103,35 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
             cast(Pump, self._device).build_set_operating_mode_obj(mode),
         )
         _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)
+
+
+class GardenaPumpDrippingAlert(GardenaEntity, SelectEntity):
+    _attr_options = list(_OPTION_TO_DRIPPING_ALERT.keys())
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_dripping_alert"
+        self._attr_name = "Dripping Alert Timeout"
+
+    @property
+    def current_option(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        alert = device.dripping_alert
+        return _DRIPPING_ALERT_TO_OPTION.get(alert) if alert is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        alert = _OPTION_TO_DRIPPING_ALERT[option]
+        await self.coordinator.send_request(
+            self._device.id,
+            cast(Pump, self._device).build_set_dripping_alert_obj(alert.value),
+        )
+        _LOGGER.info(
+            "Set dripping alert timeout for device %s to %s", self._device.id, option
+        )

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -139,7 +139,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaTemperatureSensor(GardenaEntity, SensorEntity):

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -57,7 +57,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaPowerSwitch(GardenaEntity, SwitchEntity):

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
@@ -81,14 +81,16 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_enable_output_obj(DEFAULT_ON_DURATION_SECONDS),
+            cast(PowerAdapter, self._device).build_enable_output_obj(
+                DEFAULT_ON_DURATION_SECONDS
+            ),
         )
         _LOGGER.info("Turning on switch %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_disable_output_obj(),
+            cast(PowerAdapter, self._device).build_disable_output_obj(),
         )
         _LOGGER.info("Turning off switch %s", self._device.id)
 
@@ -113,13 +115,13 @@ class GardenaPumpSwitch(GardenaEntity, SwitchEntity):
     async def async_turn_on(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_start_obj(DEFAULT_ON_DURATION_SECONDS),
+            cast(Pump, self._device).build_start_obj(DEFAULT_ON_DURATION_SECONDS),
         )
         _LOGGER.info("Turning on pump %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_stop_obj(),
+            cast(Pump, self._device).build_stop_obj(),
         )
         _LOGGER.info("Turning off pump %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -76,6 +76,16 @@
           "host": "IP-Adresse oder Hostname des GARDENA smart Gateways",
           "password": "Erster Block der Gateway-ID auf der Rückseite des Geräts (z. B. `0824b95b` aus `0824b95b-996c-48f7-83dc-…`)."
         }
+      },
+      "reauth_confirm": {
+        "title": "GARDENA smart Gateway erneut authentifizieren",
+        "description": "Das Passwort für dein GARDENA smart Gateway ist nicht mehr gültig. Gib das aktuelle Passwort ein, um die Verbindung wiederherzustellen.",
+        "data": {
+          "password": "Passwort"
+        },
+        "data_description": {
+          "password": "Erster Block der Gateway-ID auf der Rückseite des Geräts (z. B. `0824b95b` aus `0824b95b-996c-48f7-83dc-…`)."
+        }
       }
     },
     "error": {
@@ -86,7 +96,8 @@
     "abort": {
       "already_configured": "Gateway ist bereits konfiguriert",
       "already_in_progress": "Das Gateway wurde anscheinend automatisch erkannt, klicke stattdessen auf \"Hinzufügen\" bei der erkannten Integration",
-      "reconfigure_successful": "GARDENA smart Gateway-Einstellungen aktualisiert"
+      "reconfigure_successful": "GARDENA smart Gateway-Einstellungen aktualisiert",
+      "reauth_successful": "Erneute Authentifizierung erfolgreich"
     }
   }
 }

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -76,6 +76,16 @@
           "host": "IP address or hostname of your GARDENA smart Gateway",
           "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
         }
+      },
+      "reauth_confirm": {
+        "title": "Reauthenticate GARDENA smart Gateway",
+        "description": "The password for your GARDENA smart Gateway is no longer valid. Enter the current password to reconnect.",
+        "data": {
+          "password": "Password"
+        },
+        "data_description": {
+          "password": "First block of the gateway ID printed on the back of the device (e.g. `0824b95b` from `0824b95b-996c-48f7-83dc-…`)."
+        }
       }
     },
     "error": {
@@ -86,7 +96,8 @@
     "abort": {
       "already_configured": "Gateway is already configured",
       "already_in_progress": "It seems the gateway has been autodetected, click \"Add\" on discovered integration instead",
-      "reconfigure_successful": "GARDENA smart Gateway settings updated"
+      "reconfigure_successful": "GARDENA smart Gateway settings updated",
+      "reauth_successful": "Re-authentication was successful"
     }
   }
 }

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -50,7 +50,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaFirmwareUpdate(GardenaEntity, UpdateEntity):

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -72,7 +72,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaValve(GardenaEntity, ValveEntity):

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, Protocol, cast
 
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.config_entries import ConfigEntry
@@ -15,12 +15,23 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import Device
+from gardena_smart_local_api.messages import EgressMessageList
 
 _LOGGER = logging.getLogger(__name__)
 
 # Actions send commands to the gateway's local websocket — cap at 1 so HA
 # serializes them instead of firing concurrent commands at the same connection
 PARALLEL_UPDATES = 1
+
+
+class _ValveCapableDevice(Protocol):
+    valve_ids: list[int]
+
+    def build_open_valve_obj(
+        self, valve_id: int = 0, duration_seconds: int = 0
+    ) -> EgressMessageList: ...
+
+    def build_close_valve_obj(self, valve_id: int = 0) -> EgressMessageList: ...
 
 
 async def async_setup_entry(
@@ -74,7 +85,8 @@ class GardenaValve(GardenaEntity, ValveEntity):
         super().__init__(coordinator, device)
         self._valve_id = valve_id
         self._attr_unique_id = f"{device.id}_valve_{valve_id}"
-        self._attr_name = f"Valve {valve_id + 1}" if len(device.valve_ids) > 1 else None
+        valve_count = len(cast(_ValveCapableDevice, device).valve_ids)
+        self._attr_name = f"Valve {valve_id + 1}" if valve_count > 1 else None
         self._attr_reports_position = False
         self._attr_supported_features = (
             ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE
@@ -100,13 +112,17 @@ class GardenaValve(GardenaEntity, ValveEntity):
     async def async_open_valve(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_open_valve_obj(self._valve_id, 1800),
+            cast(_ValveCapableDevice, self._device).build_open_valve_obj(
+                self._valve_id, 1800
+            ),
         )
         _LOGGER.info("Opening valve %s valve_id=%s", self._device.id, self._valve_id)
 
     async def async_close_valve(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_close_valve_obj(self._valve_id),
+            cast(_ValveCapableDevice, self._device).build_close_valve_obj(
+                self._valve_id
+            ),
         )
         _LOGGER.info("Closing valve %s valve_id=%s", self._device.id, self._valve_id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dev = [
     "reuse>=6.2.0",
     "pytest-homeassistant-custom-component>=0.13",
     "gardena-smart-local-api==0.1.0",
+    "ty>=0.0.59",
 ]
 
 [tool.pytest.ini_options]

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -293,6 +293,65 @@ async def test_reconfigure_cannot_connect(hass: HomeAssistant) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Reauthentication flow
+# ---------------------------------------------------------------------------
+
+
+async def test_reauth_success(hass: HomeAssistant, mock_setup_entry) -> None:
+    """Successful reauthentication updates the stored password."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_HOST,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT, CONF_PASSWORD: "old-pw"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+
+    with patch(PATCH_TRY_CONNECT, return_value=None):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_PASSWORD: MOCK_PASSWORD}
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == MOCK_PASSWORD
+    assert entry.data[CONF_HOST] == MOCK_HOST
+
+
+async def test_reauth_invalid_auth(hass: HomeAssistant) -> None:
+    """Wrong password during reauth keeps the form open with an error."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_HOST,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT, CONF_PASSWORD: "old-pw"},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reauth_flow(hass)
+
+    with patch(
+        "aiohttp.ClientSession.ws_connect",
+        side_effect=aiohttp.WSServerHandshakeError(
+            request_info=MagicMock(),
+            history=(),
+            status=401,
+            message="Unauthorized",
+        ),
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"], {CONF_PASSWORD: "still-wrong"}
+        )
+
+    assert result["type"] == "form"
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "invalid_auth"}
+    assert entry.data[CONF_PASSWORD] == "old-pw"
+
+
+# ---------------------------------------------------------------------------
 # Import flow (YAML)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -212,6 +212,55 @@ async def test_zeroconf_already_configured(hass: HomeAssistant) -> None:
     assert result["reason"] == "already_configured"
 
 
+async def test_zeroconf_already_configured_by_host_manual_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Zeroconf discovery aborts when a manually-added entry has the same host.
+
+    The manual entry's unique_id is the host itself, while zeroconf uses the
+    mDNS name, so they wouldn't collide on unique_id alone.
+    """
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_HOST,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT, CONF_PASSWORD: MOCK_PASSWORD},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": SOURCE_ZEROCONF},
+        data=_make_zeroconf_info(),
+    )
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
+async def test_user_flow_already_configured_by_host_zeroconf_entry(
+    hass: HomeAssistant,
+) -> None:
+    """Manual setup aborts when a zeroconf-discovered entry has the same host.
+
+    The zeroconf entry's unique_id is the mDNS name, while manual setup uses
+    the host itself, so they wouldn't collide on unique_id alone.
+    """
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="gardena-gw-1234",
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT, CONF_PASSWORD: MOCK_PASSWORD},
+    ).add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT, CONF_PASSWORD: MOCK_PASSWORD},
+    )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
 async def test_zeroconf_confirm_cannot_connect(hass: HomeAssistant) -> None:
     """Failed connection at zeroconf confirmation shows an error."""
     result = await hass.config_entries.flow.async_init(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -144,7 +144,8 @@ async def test_ws_loop_reconnects_after_exception(
         patch.object(coordinator_module.asyncio, "sleep", fake_sleep),
         caplog.at_level(logging.ERROR),
     ):
-        await coordinator.async_connect()
+        with pytest.raises(aiohttp.ClientConnectionError):
+            await coordinator.async_connect()
         await real_sleep(0.05)
 
     assert sleep_calls == [5]
@@ -170,7 +171,8 @@ async def test_ws_loop_401_starts_reauth_and_stops_retrying(
         patch(PATCH_CLIENTSESSION, return_value=session),
         caplog.at_level(logging.ERROR),
     ):
-        await coordinator.async_connect()
+        with pytest.raises(aiohttp.WSServerHandshakeError):
+            await coordinator.async_connect()
         await _pump()
 
     assert session.ws_connect.call_count == 1
@@ -207,7 +209,8 @@ async def test_ws_loop_non_401_handshake_error_reconnects(
         patch.object(coordinator_module.asyncio, "sleep", fake_sleep),
         caplog.at_level(logging.ERROR),
     ):
-        await coordinator.async_connect()
+        with pytest.raises(aiohttp.WSServerHandshakeError):
+            await coordinator.async_connect()
         await real_sleep(0.05)
 
     assert sleep_calls == [5]
@@ -226,7 +229,8 @@ async def test_ws_loop_cancelled_on_connect_breaks_cleanly(
         patch(PATCH_CLIENTSESSION, return_value=session),
         caplog.at_level(logging.ERROR),
     ):
-        await coordinator.async_connect()
+        with pytest.raises(asyncio.CancelledError):
+            await coordinator.async_connect()
         await _pump()
 
     assert coordinator._task.done()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -151,6 +151,69 @@ async def test_ws_loop_reconnects_after_exception(
     assert session.ws_connect.call_count == 2
 
 
+async def test_ws_loop_401_starts_reauth_and_stops_retrying(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator.config_entry = MagicMock()
+    session = _session_with(
+        [
+            aiohttp.WSServerHandshakeError(
+                request_info=MagicMock(), history=(), status=401, message="Unauthorized"
+            )
+        ]
+    )
+
+    with (
+        patch(PATCH_CLIENTSESSION, return_value=session),
+        caplog.at_level(logging.ERROR),
+    ):
+        await coordinator.async_connect()
+        await _pump()
+
+    assert session.ws_connect.call_count == 1
+    coordinator.config_entry.async_start_reauth.assert_called_once_with(hass)
+    assert "Authentication failed" in caplog.text
+    assert coordinator._task.done()
+
+
+async def test_ws_loop_non_401_handshake_error_reconnects(
+    hass: HomeAssistant,
+    coordinator: GardenaSmartLocalCoordinator,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    coordinator.config_entry = MagicMock()
+    session = _session_with(
+        [
+            aiohttp.WSServerHandshakeError(
+                request_info=MagicMock(),
+                history=(),
+                status=500,
+                message="Server error",
+            ),
+            asyncio.CancelledError(),
+        ]
+    )
+    sleep_calls: list[float] = []
+    real_sleep = asyncio.sleep
+
+    async def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    with (
+        patch(PATCH_CLIENTSESSION, return_value=session),
+        patch.object(coordinator_module.asyncio, "sleep", fake_sleep),
+        caplog.at_level(logging.ERROR),
+    ):
+        await coordinator.async_connect()
+        await real_sleep(0.05)
+
+    assert sleep_calls == [5]
+    assert session.ws_connect.call_count == 2
+    coordinator.config_entry.async_start_reauth.assert_not_called()
+
+
 async def test_ws_loop_cancelled_on_connect_breaks_cleanly(
     hass: HomeAssistant,
     coordinator: GardenaSmartLocalCoordinator,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -945,6 +945,18 @@ def test_update_device_updates_existing_device(
     assert coordinator._devices["device-1"] is new
 
 
+def test_update_devices_drops_device_missing_from_discovery(
+    coordinator: GardenaSmartLocalCoordinator, mock_device
+) -> None:
+    coordinator._devices["stale"] = mock_device(device_id="stale")
+    fresh = mock_device(device_id="device-1")
+
+    coordinator._update_devices(_device_map(**{"device-1": fresh}))
+
+    assert "stale" not in coordinator._devices
+    assert coordinator._devices["device-1"] is fresh
+
+
 def test_update_devices_handles_exception(
     coordinator: GardenaSmartLocalCoordinator,
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -93,10 +93,47 @@ async def test_async_connect_sets_up_task_and_ssl_context(
         assert coordinator._ssl_context is not None
         coordinator._do_discovery.assert_awaited_once()
         assert coordinator._ws is ws
+        assert coordinator.connected is True
 
     await coordinator.async_disconnect()
     assert coordinator._ws is None
     assert coordinator._pending_replies == {}
+    assert coordinator.connected is False
+
+
+async def test_connected_false_when_ws_closed(
+    coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    ws = fake_ws()
+    ws.closed = True
+    coordinator._ws = ws
+    assert coordinator.connected is False
+
+
+async def test_connected_false_when_never_connected(
+    coordinator: GardenaSmartLocalCoordinator,
+) -> None:
+    assert coordinator.connected is False
+
+
+async def test_ws_loop_notifies_listeners_on_disconnect(
+    hass: HomeAssistant, coordinator: GardenaSmartLocalCoordinator, fake_ws
+) -> None:
+    coordinator._do_discovery = AsyncMock()
+    ws = fake_ws()
+    session = _session_with([ws, asyncio.CancelledError()])
+    listener = MagicMock()
+    coordinator.async_add_listener(listener)
+
+    with patch(PATCH_CLIENTSESSION, return_value=session):
+        await coordinator.async_connect()
+        await _pump()
+        listener.reset_mock()
+
+        ws.simulate_close()
+        await _pump()
+
+    listener.assert_called()
 
 
 async def test_ws_loop_reconnects_after_reader_exit(

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.gardena_smart_local_preview import (
     coordinator as coordinator_module,
@@ -958,17 +959,17 @@ def test_update_devices_handles_exception(
 # ---------------------------------------------------------------------------
 
 
-async def test_send_request_without_ws_returns_empty(
+async def test_send_request_without_ws_raises(
     coordinator: GardenaSmartLocalCoordinator,
 ) -> None:
     from gardena_smart_local_api.devices import build_discovery_obj
 
     coordinator._ws = None
-    result = await coordinator.send_request("device-1", build_discovery_obj())
-    assert list(result) == []
+    with pytest.raises(HomeAssistantError):
+        await coordinator.send_request("device-1", build_discovery_obj())
 
 
-async def test_send_request_with_closed_ws_returns_empty(
+async def test_send_request_with_closed_ws_raises(
     coordinator: GardenaSmartLocalCoordinator, fake_ws
 ) -> None:
     from gardena_smart_local_api.devices import build_discovery_obj
@@ -976,8 +977,8 @@ async def test_send_request_with_closed_ws_returns_empty(
     ws = fake_ws()
     ws.closed = True
     coordinator._ws = ws
-    result = await coordinator.send_request("device-1", build_discovery_obj())
-    assert list(result) == []
+    with pytest.raises(HomeAssistantError):
+        await coordinator.send_request("device-1", build_discovery_obj())
     assert ws.sent == []
 
 

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -113,6 +113,17 @@ def test_gardena_entity_unavailable_when_missing_from_coordinator_data(
     assert entity.available is False
 
 
+def test_gardena_entity_unavailable_when_gateway_disconnected(mock_device) -> None:
+    device = mock_device(device_id="device-1", is_online=True)
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+    coordinator.connected = False
+
+    entity = GardenaEntity(coordinator, device)
+
+    assert entity.available is False
+
+
 # ---------------------------------------------------------------------------
 # _handle_coordinator_update: device registry sw_version sync
 # ---------------------------------------------------------------------------

--- a/tests/test_entity.py
+++ b/tests/test_entity.py
@@ -6,7 +6,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 from homeassistant.helpers import device_registry as dr
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -16,6 +16,19 @@ from custom_components.gardena_smart_local_preview.entity import (
     GardenaEntity,
     find_device_subentry_id,
 )
+
+PATCH_DR_ASYNC_GET = "custom_components.gardena_smart_local_preview.entity.dr.async_get"
+
+
+def _make_entity_for_update_test(
+    coordinator, device
+) -> tuple[GardenaEntity, MagicMock]:
+    """Build a GardenaEntity wired up enough to exercise _handle_coordinator_update."""
+    entity = GardenaEntity(coordinator, device)
+    entity.hass = MagicMock()
+    entity.async_write_ha_state = MagicMock()
+    entity.device_entry = MagicMock(id="registry-device-id", sw_version="0.9")
+    return entity, entity.device_entry
 
 
 def _make_entry_with_subentries(subentries: dict) -> MockConfigEntry:
@@ -98,3 +111,91 @@ def test_gardena_entity_unavailable_when_missing_from_coordinator_data(
     entity = GardenaEntity(coordinator, device)
 
     assert entity.available is False
+
+
+# ---------------------------------------------------------------------------
+# _handle_coordinator_update: device registry sw_version sync
+# ---------------------------------------------------------------------------
+
+
+def test_handle_coordinator_update_syncs_changed_sw_version(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "1.1"
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, device_entry = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_called_once_with(
+        device_entry.id, sw_version="1.1"
+    )
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_sw_version_unchanged(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "0.9"
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_device_missing(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "1.1"
+    coordinator = MagicMock()
+    coordinator.data = {}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_no_software_version(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = None
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()
+
+
+def test_handle_coordinator_update_noop_when_no_device_entry(mock_device) -> None:
+    device = mock_device(device_id="device-1")
+    device.software_version = "1.1"
+    coordinator = MagicMock()
+    coordinator.data = {"device-1": device}
+
+    entity, _ = _make_entity_for_update_test(coordinator, device)
+    entity.device_entry = None
+    dev_reg = MagicMock()
+
+    with patch(PATCH_DR_ASYNC_GET, return_value=dev_reg):
+        entity._handle_coordinator_update()
+
+    dev_reg.async_update_device.assert_not_called()
+    entity.async_write_ha_state.assert_called_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,7 +6,9 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
 
 from homeassistant.config_entries import (
     SIGNAL_CONFIG_ENTRY_CHANGED,
@@ -82,6 +84,68 @@ async def test_setup_entry_connects_and_forwards_platforms(hass) -> None:
     assert entry.state is ConfigEntryState.LOADED
     assert isinstance(entry.runtime_data, GardenaSmartLocalCoordinator)
     mock_connect.assert_called_once()
+
+
+async def test_setup_entry_retries_on_connect_failure(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch(PATCH_CONNECT, AsyncMock(side_effect=RuntimeError("boom"))),
+        patch(PATCH_DISCONNECT, AsyncMock()) as mock_disconnect,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    mock_disconnect.assert_called_once()
+
+
+async def test_setup_entry_fails_auth_on_401(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+    error = aiohttp.WSServerHandshakeError(
+        request_info=MagicMock(), history=(), status=401, message="Unauthorized"
+    )
+
+    with (
+        patch(PATCH_CONNECT, AsyncMock(side_effect=error)),
+        patch(PATCH_DISCONNECT, AsyncMock()) as mock_disconnect,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_ERROR
+    mock_disconnect.assert_called_once()
+    flows = hass.config_entries.flow.async_progress_by_handler(DOMAIN)
+    assert any(flow["context"]["source"] == "reauth" for flow in flows)
+
+
+async def test_setup_entry_non_401_handshake_error_retries(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+    error = aiohttp.WSServerHandshakeError(
+        request_info=MagicMock(), history=(), status=500, message="Server error"
+    )
+
+    with (
+        patch(PATCH_CONNECT, AsyncMock(side_effect=error)),
+        patch(PATCH_DISCONNECT, AsyncMock()) as mock_disconnect,
+    ):
+        assert not await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.SETUP_RETRY
+    mock_disconnect.assert_called_once()
 
 
 async def test_setup_entry_creates_subentry_for_discovered_device(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,210 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local integration setup/unload."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    ConfigEntryChange,
+    ConfigEntryState,
+)
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
+from homeassistant.helpers import device_registry as dr
+from homeassistant.helpers.dispatcher import async_dispatcher_send
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.gardena_smart_local_preview import DOMAIN, async_setup
+from custom_components.gardena_smart_local_preview.coordinator import (
+    GardenaSmartLocalCoordinator,
+)
+
+PATCH_CONNECT = (
+    "custom_components.gardena_smart_local_preview.coordinator."
+    "GardenaSmartLocalCoordinator.async_connect"
+)
+PATCH_DISCONNECT = (
+    "custom_components.gardena_smart_local_preview.coordinator."
+    "GardenaSmartLocalCoordinator.async_disconnect"
+)
+
+
+def _mock_connect():
+    return patch(PATCH_CONNECT, AsyncMock())
+
+
+def _mock_disconnect():
+    return patch(PATCH_DISCONNECT, AsyncMock())
+
+
+async def test_async_setup_without_domain_config_is_noop(hass) -> None:
+    result = await async_setup(hass, {})
+
+    assert result is True
+    assert hass.config_entries.async_entries(DOMAIN) == []
+
+
+async def test_async_setup_imports_yaml_config(hass) -> None:
+    with _mock_connect(), _mock_disconnect():
+        result = await async_setup(
+            hass,
+            {
+                DOMAIN: {
+                    CONF_HOST: "192.168.1.50",
+                    CONF_PORT: 8443,
+                    CONF_PASSWORD: "secret",
+                }
+            },
+        )
+        await hass.async_block_till_done()
+
+    assert result is True
+    entries = hass.config_entries.async_entries(DOMAIN)
+    assert len(entries) == 1
+    assert entries[0].data[CONF_HOST] == "192.168.1.50"
+
+
+async def test_setup_entry_connects_and_forwards_platforms(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect() as mock_connect, _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.LOADED
+    assert isinstance(entry.runtime_data, GardenaSmartLocalCoordinator)
+    mock_connect.assert_called_once()
+
+
+async def test_setup_entry_creates_subentry_for_discovered_device(
+    hass, mock_device
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect(), _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        device = mock_device(device_id="device-1", name="Water Control")
+        coordinator._devices["device-1"] = device
+        coordinator.async_set_updated_data(coordinator._devices)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    subentries = list(entry.subentries.values())
+    assert len(subentries) == 1
+    assert subentries[0].data["device_id"] == "device-1"
+    assert subentries[0].title == "Water Control SN123"
+
+
+async def test_setup_entry_migrates_legacy_device_to_subentry(
+    hass, mock_device
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    dev_reg = dr.async_get(hass)
+    legacy_device = dev_reg.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        config_subentry_id=None,
+        identifiers={(DOMAIN, "device-1")},
+    )
+
+    with _mock_connect(), _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        device = mock_device(device_id="device-1", name="Water Control")
+        coordinator._devices["device-1"] = device
+        coordinator.async_set_updated_data(coordinator._devices)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    updated_device = dev_reg.async_get(legacy_device.id)
+    assert updated_device is not None
+    subentry_id = next(iter(entry.subentries.keys()))
+    assert None not in updated_device.config_entries_subentries.get(
+        entry.entry_id, set()
+    )
+    assert subentry_id in updated_device.config_entries_subentries.get(
+        entry.entry_id, set()
+    )
+
+
+async def test_entry_updated_excludes_device_when_subentry_removed(
+    hass, mock_device
+) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect(), _mock_disconnect():
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        coordinator = entry.runtime_data
+        device = mock_device(device_id="device-1", name="Water Control")
+        coordinator._devices["device-1"] = device
+        coordinator.async_set_updated_data(coordinator._devices)
+        await hass.async_block_till_done()
+
+        # Sync the closure's known-subentries cache with reality.
+        async_dispatcher_send(
+            hass, SIGNAL_CONFIG_ENTRY_CHANGED, ConfigEntryChange.UPDATED, entry
+        )
+        await hass.async_block_till_done()
+
+        subentry_id = next(iter(entry.subentries.keys()))
+
+        with patch.object(
+            GardenaSmartLocalCoordinator, "async_exclude_device", AsyncMock()
+        ) as mock_exclude:
+            # Removing the subentry fires SIGNAL_CONFIG_ENTRY_CHANGED itself.
+            hass.config_entries.async_remove_subentry(entry, subentry_id)
+            await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    mock_exclude.assert_called_once_with("device-1")
+
+
+async def test_unload_entry_disconnects_coordinator(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={CONF_HOST: "192.168.1.50", CONF_PORT: 8443, CONF_PASSWORD: "secret"},
+    )
+    entry.add_to_hass(hass)
+
+    with _mock_connect(), _mock_disconnect() as mock_disconnect:
+        assert await hass.config_entries.async_setup(entry.entry_id)
+        await hass.async_block_till_done()
+
+        assert await hass.config_entries.async_unload(entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert entry.state is ConfigEntryState.NOT_LOADED
+    mock_disconnect.assert_called_once()

--- a/tests/test_lawn_mower.py
+++ b/tests/test_lawn_mower.py
@@ -91,13 +91,45 @@ def test_gen2_mower_has_pause_feature(coordinator, spec_device) -> None:
         (MowerState.MOWING, LawnMowerActivity.MOWING),
         (MowerState.PAUSED, LawnMowerActivity.PAUSED),
         (MowerState.RETURNING, LawnMowerActivity.RETURNING),
-        (MowerState.UNKNOWN, LawnMowerActivity.ERROR),
+        (MowerState.ERROR, LawnMowerActivity.ERROR),
+        (MowerState.UNKNOWN, None),
     ],
 )
-def test_activity_maps_mower_state(coordinator, spec_device, state, expected) -> None:
+def test_activity_maps_mower_state(
+    coordinator, spec_device, sync_devices, state, expected
+) -> None:
     device = spec_device(Gen1Mower1, device_id="device-1", state=state)
+    coordinator._devices["device-1"] = device
+    sync_devices()
     entity = lawn_mower.GardenaMower(coordinator, device)
     assert entity.activity == expected
+
+
+def test_activity_none_when_device_missing_from_coordinator(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1Mower1, device_id="device-1", state=MowerState.MOWING)
+    sync_devices()
+    entity = lawn_mower.GardenaMower(coordinator, device)
+    assert entity.activity is None
+
+
+def test_activity_reflects_current_coordinator_state_not_stale_device(
+    coordinator, spec_device, sync_devices
+) -> None:
+    """Rediscovery replaces Device objects; activity must not use the stale one."""
+    device = spec_device(Gen1Mower1, device_id="device-1", state=MowerState.MOWING)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = lawn_mower.GardenaMower(coordinator, device)
+
+    updated_device = spec_device(
+        Gen1Mower1, device_id="device-1", state=MowerState.PARKED
+    )
+    coordinator._devices["device-1"] = updated_device
+    sync_devices()
+
+    assert entity.activity == LawnMowerActivity.DOCKED
 
 
 async def test_async_start_mowing(coordinator, spec_device) -> None:

--- a/tests/test_number.py
+++ b/tests/test_number.py
@@ -28,7 +28,7 @@ async def test_setup_adds_button_config_time_for_water_control(
     assert kwargs["config_subentry_id"] is None
 
 
-async def test_setup_adds_two_number_entities_for_pump(
+async def test_setup_adds_one_number_entity_for_pump(
     coordinator, entry, setup_platform, spec_device, sync_devices
 ) -> None:
     async_add_entities = await setup_platform(number, entry)
@@ -38,9 +38,8 @@ async def test_setup_adds_two_number_entities_for_pump(
 
     async_add_entities.assert_called_once()
     (entities,), _ = async_add_entities.call_args
-    assert len(entities) == 2
+    assert len(entities) == 1
     assert isinstance(entities[0], number.GardenaPumpTurnOnPressure)
-    assert isinstance(entities[1], number.GardenaPumpDrippingAlert)
 
 
 async def test_setup_skips_non_matching_device(
@@ -158,39 +157,4 @@ async def test_turn_on_pressure_set_native_value(coordinator, spec_device) -> No
     device.build_set_turn_on_pressure_obj.assert_called_once_with(3.2)
     coordinator.send_request.assert_awaited_once_with(
         "device-1", device.build_set_turn_on_pressure_obj.return_value
-    )
-
-
-# ---------------------------------------------------------------------------
-# GardenaPumpDrippingAlert
-# ---------------------------------------------------------------------------
-
-
-def test_dripping_alert_native_value(coordinator, spec_device, sync_devices) -> None:
-    device = spec_device(Pump, device_id="device-1", dripping_alert=120)
-    coordinator._devices["device-1"] = device
-    sync_devices()
-    entity = number.GardenaPumpDrippingAlert(coordinator, device)
-    assert entity.native_value == 120
-
-
-def test_dripping_alert_native_value_none_when_device_missing(
-    coordinator, spec_device, sync_devices
-) -> None:
-    device = spec_device(Pump, device_id="device-1", dripping_alert=120)
-    sync_devices()
-    entity = number.GardenaPumpDrippingAlert(coordinator, device)
-    assert entity.native_value is None
-
-
-async def test_dripping_alert_set_native_value(coordinator, spec_device) -> None:
-    device = spec_device(Pump, device_id="device-1")
-    coordinator.send_request = AsyncMock()
-    entity = number.GardenaPumpDrippingAlert(coordinator, device)
-
-    await entity.async_set_native_value(120.0)
-
-    device.build_set_dripping_alert_obj.assert_called_once_with(120)
-    coordinator.send_request.assert_awaited_once_with(
-        "device-1", device.build_set_dripping_alert_obj.return_value
     )

--- a/tests/test_select.py
+++ b/tests/test_select.py
@@ -10,12 +10,15 @@ from unittest.mock import AsyncMock
 
 import pytest
 from gardena_smart_local_api.devices import PowerAdapter, Pump
-from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
+from gardena_smart_local_api.devices.irrigation import (
+    PumpDrippingAlert,
+    PumpOperatingMode,
+)
 
 from custom_components.gardena_smart_local_preview import select
 
 
-async def test_setup_adds_select_for_pump(
+async def test_setup_adds_two_selects_for_pump(
     coordinator, entry, setup_platform, spec_device, sync_devices
 ) -> None:
     async_add_entities = await setup_platform(select, entry)
@@ -25,8 +28,9 @@ async def test_setup_adds_select_for_pump(
 
     async_add_entities.assert_called_once()
     (entities,), kwargs = async_add_entities.call_args
-    assert len(entities) == 1
+    assert len(entities) == 2
     assert isinstance(entities[0], select.GardenaPumpOperatingModeSelect)
+    assert isinstance(entities[1], select.GardenaPumpDrippingAlert)
     assert kwargs["config_subentry_id"] is None
 
 
@@ -150,6 +154,88 @@ async def test_select_option_invalid_raises_key_error(coordinator, spec_device) 
     device = spec_device(Pump, device_id="device-1")
     coordinator.send_request = AsyncMock()
     entity = select.GardenaPumpOperatingModeSelect(coordinator, device)
+
+    with pytest.raises(KeyError):
+        await entity.async_select_option("bogus")
+
+
+# ---------------------------------------------------------------------------
+# GardenaPumpDrippingAlert
+# ---------------------------------------------------------------------------
+
+
+def test_dripping_alert_options(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
+    assert entity.options == ["60_minutes", "2_minutes", "off"]
+
+
+def test_dripping_alert_current_option(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Pump, device_id="device-1", dripping_alert=PumpDrippingAlert.MINUTES_2
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
+    assert entity.current_option == "2_minutes"
+
+
+def test_dripping_alert_current_option_off(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Pump,
+        device_id="device-1",
+        dripping_alert=PumpDrippingAlert.DRIPPING_ALERT_OFF,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
+    assert entity.current_option == "off"
+
+
+def test_dripping_alert_current_option_none_when_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Pump, device_id="device-1", dripping_alert=PumpDrippingAlert.MINUTES_60
+    )
+    sync_devices()
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
+    assert entity.current_option is None
+
+
+def test_dripping_alert_current_option_none_when_alert_none(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Pump, device_id="device-1", dripping_alert=None)
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
+    assert entity.current_option is None
+
+
+async def test_dripping_alert_select_option(coordinator, spec_device) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
+
+    await entity.async_select_option("60_minutes")
+
+    device.build_set_dripping_alert_obj.assert_called_once_with(
+        PumpDrippingAlert.MINUTES_60.value
+    )
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_set_dripping_alert_obj.return_value
+    )
+
+
+async def test_dripping_alert_select_option_invalid_raises_key_error(
+    coordinator, spec_device
+) -> None:
+    device = spec_device(Pump, device_id="device-1")
+    coordinator.send_request = AsyncMock()
+    entity = select.GardenaPumpDrippingAlert(coordinator, device)
 
     with pytest.raises(KeyError):
         await entity.async_select_option("bogus")

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,0 +1,366 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the GARDENA smart local firmware update entity."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+from gardena_smart_local_api.devices import Gen1WaterControl
+from gardena_smart_local_api.devices.device import FirmwareUpdateState
+
+from custom_components.gardena_smart_local_preview import update
+
+
+# ---------------------------------------------------------------------------
+# async_setup_entry
+# ---------------------------------------------------------------------------
+
+
+async def test_setup_adds_update_entity_for_device(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(update, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+    (entities,), kwargs = async_add_entities.call_args
+    assert len(entities) == 1
+    assert isinstance(entities[0], update.GardenaFirmwareUpdate)
+    assert kwargs["config_subentry_id"] is None
+
+
+async def test_setup_noop_when_coordinator_data_empty(
+    coordinator, entry, setup_platform, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(update, entry)
+    sync_devices()
+    async_add_entities.assert_not_called()
+
+
+async def test_setup_dedups_on_repeated_firing(
+    coordinator, entry, setup_platform, spec_device, sync_devices
+) -> None:
+    async_add_entities = await setup_platform(update, entry)
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+
+    sync_devices()
+    sync_devices()
+
+    async_add_entities.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# installed_version / latest_version
+# ---------------------------------------------------------------------------
+
+
+def test_installed_version_returns_software_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1", software_version="1.0")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.installed_version == "1.0"
+
+
+def test_installed_version_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.installed_version is None
+
+
+def test_latest_version_none_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version is None
+
+
+def test_latest_version_downloaded_uses_available_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.DOWNLOADED,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "2.0"
+
+
+def test_latest_version_downloaded_falls_back_to_installed(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.DOWNLOADED,
+        available_software_version=None,
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "1.0"
+
+
+def test_latest_version_updating_uses_held_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity._held_latest_version = "1.9"
+    assert entity.latest_version == "1.9"
+
+
+def test_latest_version_updating_falls_back_to_available_then_installed(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "2.0"
+
+
+def test_latest_version_idle_returns_installed_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.IDLE,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "1.0"
+
+
+def test_latest_version_downloading_returns_installed_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.DOWNLOADING,
+        available_software_version="2.0",
+        software_version="1.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.latest_version == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# _handle_coordinator_update: held target version while updating
+# ---------------------------------------------------------------------------
+
+
+def test_handle_coordinator_update_holds_version_on_entering_updating(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version == "2.0"
+
+
+def test_handle_coordinator_update_keeps_existing_held_version(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+        available_software_version="2.0",
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+    entity._held_latest_version = "1.9"
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version == "1.9"
+
+
+def test_handle_coordinator_update_clears_held_version_when_not_in_progress(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.IDLE,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+    entity._held_latest_version = "1.9"
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version is None
+
+
+def test_handle_coordinator_update_noop_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.async_write_ha_state = lambda: None
+    entity._held_latest_version = "1.9"
+
+    entity._handle_coordinator_update()
+
+    assert entity._held_latest_version == "1.9"
+
+
+# ---------------------------------------------------------------------------
+# version_is_newer / in_progress
+# ---------------------------------------------------------------------------
+
+
+def test_version_is_newer_true_for_downgrade(coordinator, spec_device) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.version_is_newer("1.0", "2.0") is True
+
+
+def test_version_is_newer_false_when_equal(coordinator, spec_device) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.version_is_newer("1.0", "1.0") is False
+
+
+def test_in_progress_true_when_updating(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.UPDATING,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.in_progress is True
+
+
+def test_in_progress_false_when_idle(coordinator, spec_device, sync_devices) -> None:
+    device = spec_device(
+        Gen1WaterControl,
+        device_id="device-1",
+        firmware_update_state=FirmwareUpdateState.IDLE,
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.in_progress is False
+
+
+def test_in_progress_false_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    assert entity.in_progress is False
+
+
+# ---------------------------------------------------------------------------
+# async_install / async_added_to_hass
+# ---------------------------------------------------------------------------
+
+
+async def test_async_install_holds_version_and_sends_request(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(
+        Gen1WaterControl, device_id="device-1", available_software_version="2.0"
+    )
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    coordinator.send_request = AsyncMock()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+
+    await entity.async_install(version="2.0", backup=False)
+
+    assert entity._held_latest_version == "2.0"
+    device.build_install_firmware_update_obj.assert_called_once_with()
+    coordinator.send_request.assert_awaited_once_with(
+        "device-1", device.build_install_firmware_update_obj.return_value
+    )
+
+
+async def test_async_install_noop_hold_when_device_missing(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    sync_devices()
+    coordinator.send_request = AsyncMock()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+
+    await entity.async_install(version="2.0", backup=False)
+
+    assert entity._held_latest_version is None
+    coordinator.send_request.assert_awaited_once()
+
+
+async def test_async_added_to_hass_refreshes_firmware(
+    coordinator, spec_device, sync_devices
+) -> None:
+    device = spec_device(Gen1WaterControl, device_id="device-1")
+    coordinator._devices["device-1"] = device
+    sync_devices()
+    coordinator.async_refresh_firmware = AsyncMock()
+    entity = update.GardenaFirmwareUpdate(coordinator, device)
+    entity.hass = coordinator.hass
+
+    await entity.async_added_to_hass()
+
+    coordinator.async_refresh_firmware.assert_awaited_once_with("device-1")

--- a/uv.lock
+++ b/uv.lock
@@ -2095,6 +2095,7 @@ dev = [
     { name = "pytest-homeassistant-custom-component", version = "0.13.316", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.13.2' and python_full_version < '3.14.2'" },
     { name = "pytest-homeassistant-custom-component", version = "0.13.345", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.14.2'" },
     { name = "reuse" },
+    { name = "ty" },
 ]
 
 [package.metadata]
@@ -2104,6 +2105,7 @@ dev = [
     { name = "gardena-smart-local-api", specifier = "==0.1.0" },
     { name = "pytest-homeassistant-custom-component", specifier = ">=0.13" },
     { name = "reuse", specifier = ">=6.2.0" },
+    { name = "ty", specifier = ">=0.0.59" },
 ]
 
 [[package]]
@@ -5242,6 +5244,31 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.59"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/b0/84ae7b3bf6e3e9f57eb9635eeff5a80b36e57aa089f40be0fb5c384fa176/ty-0.0.59.tar.gz", hash = "sha256:53e53ffeed78ad59cd237fa8ea1316d2b94e13efdea9a945698acab549e005aa", size = 6145435, upload-time = "2026-07-12T20:22:02.781Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/57/e8/650b42fbef4d48e6ca682b0b6e9b68fa8fcf55cbb0a6892ab89990018b6f/ty-0.0.59-py3-none-linux_armv6l.whl", hash = "sha256:f8fb08a767ef8f11ea3c537b9d77860726cc2bc39e6f77ad13c02d5b289f20a7", size = 11700328, upload-time = "2026-07-12T20:21:26.046Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ac/0ca3a89d5f59ae5f308e5e83428cac5f9143200767743e052fba90b4b81e/ty-0.0.59-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:c7f4d5630836c8a0ba13dd4ac7bdae080a7d6ebe965b817ff642dc961bcf2a53", size = 11494310, upload-time = "2026-07-12T20:21:28.491Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f8/5076de6001cefbccd8e6dc8472262697e43308ff66b0e87c72abba136357/ty-0.0.59-py3-none-macosx_11_0_arm64.whl", hash = "sha256:872f6fb02c6db5553c4d5fb283b3d50f0985fb9a29a910e4fda4793a775c1926", size = 11026797, upload-time = "2026-07-12T20:21:30.879Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/0f/fca28481b6a138e2b798ad9fdc98a095475f9104948ba242fce4b477782b/ty-0.0.59-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2af8eefbfe806337770eec12c0c819c5f1b8f5b85f8369cb1cc9fa25234a2208", size = 11475304, upload-time = "2026-07-12T20:21:33.041Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/1fed8b81b389ef4bbc0400f19e05fc16496b162577779dc0e5fc65ac216c/ty-0.0.59-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0acf8b76a1c9a7ddef460b42475f6c76193164426ab080783af1c3175b4b999b", size = 11533131, upload-time = "2026-07-12T20:21:35.189Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/fc/04eec35e05a10e0fea1c6503a290ccc3935efda9c845aff64e83282c1af7/ty-0.0.59-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:043c2e00eb1d7475f928af7dedd71f69b64e69bfca55e36f4c968479e1373fc4", size = 12205932, upload-time = "2026-07-12T20:21:37.324Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/dd/a61de859659fa11b55917ad38340a8f2c61f5ae17d1874929f29084c6990/ty-0.0.59-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f0d688d857441df57f48fca66c029d85cf737c510e7be1d01144cdad1e58d968", size = 12758406, upload-time = "2026-07-12T20:21:39.525Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/e8/fa66f05997eab8ca75fc4f17320140e25467849e0cc75597f898cc22099c/ty-0.0.59-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a96c9f88394a3b42c737e2125b2330543f0d90a43b49761f377d96f8c3ee0d62", size = 12288176, upload-time = "2026-07-12T20:21:41.784Z" },
+    { url = "https://files.pythonhosted.org/packages/15/68/0fca59963bd5123f42d5f7da50667e7a52e8e9615e3a16d8c2c0d3b2d143/ty-0.0.59-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f08dbcb268edcafcb152e59475b5b495ce28d0b340a395c09943557678f4d5a6", size = 12028471, upload-time = "2026-07-12T20:21:43.82Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5b/cd7dabbbab392578f11179919da5c25d8c3322e5388a688f539ea0539603/ty-0.0.59-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8812764b9a40fdc98df1272826e73a298ef56b06681135e643bcf90aad1896f7", size = 12297646, upload-time = "2026-07-12T20:21:45.76Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/37/2e9c94f0b383d8cbe1a35517ab470b7810bc9d7501603ab532bcd5be5e90/ty-0.0.59-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:fd53b8581641d8dad7bfac6d5ea589e91a883d6837e0b9a286fdae30722b7c69", size = 11432519, upload-time = "2026-07-12T20:21:47.694Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/0a/af93e9785200f11ac416cc20235fc2464c9bd978e791190684ea0e458795/ty-0.0.59-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:86da5872124a41877d95058bc17d33ddcff034b587eb5f1e2917ab88ba227dac", size = 11554993, upload-time = "2026-07-12T20:21:49.671Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/dd/651bf87e20d00376c81b19124756491cffaf20eb8bec05a8794e5a8cf641/ty-0.0.59-py3-none-musllinux_1_2_i686.whl", hash = "sha256:6a233eef5f2fd4d894881e4a0aec83c9f172bfae1d787d6596ee1939fcc7723e", size = 11818230, upload-time = "2026-07-12T20:21:51.659Z" },
+    { url = "https://files.pythonhosted.org/packages/16/50/c947c4155fea751d135b19affdf734bbce72a94e446b866cf0c62f8bed69/ty-0.0.59-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:7ff678c18b5f1e3128b75a35e50dee7908dea55155baa31cd790619d5014cbf5", size = 12135194, upload-time = "2026-07-12T20:21:53.796Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/13/e5feb138888de1e95037c843571bbbd4ac21bf0a190507468098599a321f/ty-0.0.59-py3-none-win32.whl", hash = "sha256:cf8abb4b8095c5fe39102b8127f5886db308c8d4600909ddbc905512ce9c8163", size = 11179249, upload-time = "2026-07-12T20:21:55.752Z" },
+    { url = "https://files.pythonhosted.org/packages/76/dd/52914dcbeeba92c207de40ef7109a58dcb5527aeb21c8f8feb7402aa9e29/ty-0.0.59-py3-none-win_amd64.whl", hash = "sha256:1dde20a82243d24407869e5a608c2f15efddd5cefc662aef461a5af84bfb3f8b", size = 12251079, upload-time = "2026-07-12T20:21:58.1Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/8f/ac36fde77e223297454c1e0aeb8888c169eaacf3163bb609e3af942c88cb/ty-0.0.59-py3-none-win_arm64.whl", hash = "sha256:987043ee9e021f49493d9135891ac69c1affeee0d4ad4480c5fa4d9c975fc91b", size = 11650921, upload-time = "2026-07-12T20:22:00.348Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

The core PR (adding this integration to home-assistant/core) got a Copilot review pass. Most of the findings apply equally here, since this is where the code originates from. One commit per bugfix:

- Build gateway WebSocket URLs with `yarl.URL.build` (IPv6 hosts produced invalid unbracketed URLs)
- Reconnect if either WebSocket worker exits, not just the reader
- Raise instead of silently no-opping when sending on a closed socket
- Raise `ConfigEntryNotReady`/`ConfigEntryAuthFailed` when the initial connect fails (previously an unreachable gateway or wrong password was accepted as loaded)
- Run device-discovery listeners once immediately after subscribing, across all 9 platforms (previously only reacted to the *next* coordinator update, missing devices if discovery finished before the listener was registered)
- Unload platforms before disconnecting the coordinator
- Match existing entries by host across manual and zeroconf config flows (previously could create a duplicate entry for the same gateway)
- Drop devices missing from a fresh full discovery result (previously a device removed while disconnected would linger forever)
- Reflect gateway connection state in entity availability, not just the last-pushed per-device online flag
- Model the pump dripping alert as a select (3-value protocol enum), not a number that let you write arbitrary "seconds"
- Read the current coordinator device for mower activity instead of a stale captured reference, and preserve `MowerState.UNKNOWN` instead of mapping it to `LawnMowerActivity.ERROR`

Not changed (raised on the core PR, but these are intentional, not bugs):
- WebSocket transport ownership staying in the integration, not `gardena-smart-local-api` (the library is deliberately transport-agnostic)
- Factory reset on subentry delete (that's what excluding a device from the gateway actually is, same as the official app)

Base branch is `gardena/fs/quality-scale-fixes` since this stacks on top of it (shares the client-session/timeout fixes in the same files).

Tests updated/added alongside each behavior change; full suite passes (266 tests), ruff/ty clean.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>