### PR TITLE
Fix bugs found by Copilot review on the core port

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import (
     SOURCE_IMPORT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.const import (
@@ -84,7 +85,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         port=entry.data[CONF_PORT],
         password=entry.data[CONF_PASSWORD],
     )
-    await coordinator.async_connect()
+    try:
+        await coordinator.async_connect()
+    except Exception as err:
+        await coordinator.async_disconnect()
+        raise ConfigEntryNotReady(
+            f"Could not connect to GARDENA smart Gateway at {coordinator.uri}"
+        ) from err
     entry.runtime_data = coordinator
 
     async def _stop(_event: object) -> None:

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -181,6 +181,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    if not await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        return False
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     await coordinator.async_disconnect()
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    return True

--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -143,6 +143,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # Register before platform listeners so subentries exist when
     # platforms look them up for newly discovered devices.
     entry.async_on_unload(coordinator.async_add_listener(_ensure_device_subentries))
+    _ensure_device_subentries()
 
     known_subentries: dict[str, str] = {
         sid: se.data["device_id"]

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -54,7 +54,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaFrostWarningSensor(GardenaEntity, BinarySensorEntity):

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -73,7 +73,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaIdentifyButton(GardenaEntity, ButtonEntity):

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -46,6 +46,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         errors: dict[str, str] = {}
 
         if user_input is not None:
+            # A zeroconf-discovered entry for the same host would have a
+            # different (mDNS name based) unique_id, so also match on host.
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             await self.async_set_unique_id(user_input[CONF_HOST])
             self._abort_if_unique_id_configured()
 
@@ -81,6 +84,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         host = discovery_info.host
         port = discovery_info.port or DEFAULT_PORT
 
+        # A manually-added entry for the same host would have a different
+        # (host based) unique_id, so also match on host.
+        self._async_abort_entries_match({CONF_HOST: host})
         await self.async_set_unique_id(name)
         self._abort_if_unique_id_configured()
 

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -7,6 +7,7 @@ import logging
 
 import aiohttp
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -170,7 +171,7 @@ async def _async_try_connect(host: str, port: int, password: str) -> str | None:
     try:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                f"wss://{host}:{port}",
+                URL.build(scheme="wss", host=host, port=port),
                 ssl=ssl_context,
                 headers={"Authorization": f"Basic {auth_b64}"},
                 timeout=aiohttp.ClientTimeout(total=10),

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -94,6 +94,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         async with asyncio.timeout(15):
             await self._first_connect_result
 
+    @property
+    def connected(self) -> bool:
+        """Return True if the WebSocket to the gateway is currently connected."""
+        return self._ws is not None and not self._ws.closed
+
     async def async_disconnect(self) -> None:
         for handle in self._includable_timeouts.values():
             handle.cancel()
@@ -175,6 +180,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     if not fut.done():
                         fut.cancel()
                 self._pending_replies.clear()
+                # Let entities re-check availability now that we're disconnected.
+                self.async_update_listeners()
 
     async def _ws_reader(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         async for msg in ws:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 import aiohttp
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
 from yarl import URL
@@ -496,10 +497,9 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         wait_for_response_sec: float = 0,
     ) -> IngressMessageList:
         if not self._ws or self._ws.closed:
-            _LOGGER.error(
-                "Cannot send request to device %s: WebSocket not connected", device_id
+            raise HomeAssistantError(
+                f"Cannot send request to device {device_id}: WebSocket not connected"
             )
-            return IngressMessageList([])
 
         if wait_for_response_sec > 0:
             loop = asyncio.get_running_loop()

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -11,6 +11,7 @@ import aiohttp
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
+from yarl import URL
 
 from gardena_smart_local_api.devices import (
     Device,
@@ -62,7 +63,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self.host = host
         self.port = port
         self.password = password
-        self.uri = f"wss://{host}:{port}"
+        self.uri = URL.build(scheme="wss", host=host, port=port)
 
         auth_string = f"_:{password}"
         auth_bytes = auth_string.encode("utf-8")

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -499,6 +499,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
     def _update_devices(self, devices: DeviceMap) -> None:
         try:
+            for device_id in self._devices.keys() - devices.keys():
+                _LOGGER.info(
+                    "Device %s no longer present in discovery, dropping", device_id
+                )
+                del self._devices[device_id]
             for device in devices.values():
                 self._update_device(device)
         except Exception as err:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -128,8 +128,14 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
                         await self._do_discovery()
 
-                        # Block until the reader exits (disconnect / error)
-                        await reader_task
+                        # Block until either worker exits (disconnect / error), then
+                        # re-raise its exception, if any, so we reconnect below.
+                        done, _pending = await asyncio.wait(
+                            (reader_task, consumer_task),
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        for task in done:
+                            task.result()
                         _LOGGER.info(
                             "Disconnected from GARDENA smart Gateway, reconnecting"
                         )

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -78,16 +78,21 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self._pending_replies: dict[str, asyncio.Future[Reply]] = {}
         self._includable_devices: dict[str, IncludableDeviceInfo] = {}
         self._includable_timeouts: dict[str, asyncio.TimerHandle] = {}
+        self._first_connect_result: asyncio.Future[None] | None = None
 
     async def _async_update_data(self) -> DeviceMap:
         return self._devices
 
     async def async_connect(self) -> None:
+        """Connect to the gateway, waiting for the first attempt to succeed."""
         if self._ssl_context is None:
             self._ssl_context = get_default_no_verify_context()
+        self._first_connect_result = self.hass.loop.create_future()
         self._task = self.hass.async_create_background_task(
             self._ws_loop(), "gardena_smart_local_preview_websocket"
         )
+        async with asyncio.timeout(15):
+            await self._first_connect_result
 
     async def async_disconnect(self) -> None:
         for handle in self._includable_timeouts.values():
@@ -128,6 +133,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                         )
 
                         await self._do_discovery()
+                        if (
+                            self._first_connect_result
+                            and not self._first_connect_result.done()
+                        ):
+                            self._first_connect_result.set_result(None)
 
                         # Block until either worker exits (disconnect / error), then
                         # re-raise its exception, if any, so we reconnect below.
@@ -143,8 +153,12 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
             except asyncio.CancelledError:
                 _LOGGER.debug("WebSocket loop cancelled")
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.cancel()
                 break
             except Exception as err:
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.set_exception(err)
                 _LOGGER.error("WebSocket error: %s", err)
                 await asyncio.sleep(5)
             finally:

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -48,6 +48,8 @@ class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):
 
     @property
     def available(self) -> bool:
+        if not self.coordinator.connected:
+            return False
         device = self.coordinator.data.get(self._device.id)
         return bool(device and device.is_online)
 

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -56,7 +56,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaMower(GardenaEntity, LawnMowerEntity):

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -77,8 +77,11 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
             self._attr_supported_features |= LawnMowerEntityFeature.PAUSE
 
     @property
-    def activity(self) -> LawnMowerActivity:
-        mower_state = self._device.state
+    def activity(self) -> LawnMowerActivity | None:
+        device = self.coordinator.data.get(self._device.id)
+        if device is None:
+            return None
+        mower_state = device.state
         _LOGGER.debug("Mower status: %s", mower_state)
         match mower_state:
             case MowerState.CHARGING | MowerState.PARKED:
@@ -93,7 +96,11 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
             case MowerState.RETURNING:
                 return LawnMowerActivity.RETURNING
 
-        return LawnMowerActivity.ERROR
+            case MowerState.ERROR:
+                return LawnMowerActivity.ERROR
+
+        # MowerState.UNKNOWN or any state the dependency doesn't map yet.
+        return None
 
     async def async_start_mowing(self) -> None:
         await self.coordinator.send_request(

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -53,13 +53,10 @@ async def async_setup_entry(
             elif isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).extend(
-                    [
-                        GardenaPumpTurnOnPressure(coordinator, device),
-                        GardenaPumpDrippingAlert(coordinator, device),
-                    ]
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPumpTurnOnPressure(coordinator, device)
                 )
-                _LOGGER.info("Adding new pump number entities for device %s", device.id)
+                _LOGGER.info("Adding new pump number entity for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -140,40 +137,4 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
             "Set turn-on pressure for device %s to %s bar",
             self._device.id,
             value,
-        )
-
-
-class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
-    _attr_native_min_value = 0
-    _attr_native_max_value = 3600
-    _attr_native_step = 1
-    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
-    _attr_mode = NumberMode.BOX
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def __init__(
-        self,
-        coordinator: GardenaSmartLocalCoordinator,
-        device: Pump,
-    ) -> None:
-        super().__init__(coordinator, device)
-        self._attr_unique_id = f"{device.id}_dripping_alert"
-        self._attr_name = "Dripping Alert Timeout"
-
-    @property
-    def native_value(self) -> float | None:
-        device = self.coordinator.data.get(self._device.id)
-        if not device:
-            return None
-        return device.dripping_alert
-
-    async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_set_dripping_alert_obj(int(value)),
-        )
-        _LOGGER.info(
-            "Set dripping alert timeout for device %s to %s seconds",
-            self._device.id,
-            int(value),
         )

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -63,7 +63,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaButtonConfigTime(GardenaEntity, NumberEntity):

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -55,7 +55,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -8,13 +8,17 @@ import logging
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
 from gardena_smart_local_api.devices import Pump
-from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
+from gardena_smart_local_api.devices.irrigation import (
+    PumpDrippingAlert,
+    PumpOperatingMode,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -28,6 +32,15 @@ _MODE_TO_OPTION: dict[PumpOperatingMode, str] = {
 }
 _OPTION_TO_MODE: dict[str, PumpOperatingMode] = {
     v: k for k, v in _MODE_TO_OPTION.items()
+}
+
+_DRIPPING_ALERT_TO_OPTION: dict[PumpDrippingAlert, str] = {
+    PumpDrippingAlert.MINUTES_60: "60_minutes",
+    PumpDrippingAlert.MINUTES_2: "2_minutes",
+    PumpDrippingAlert.DRIPPING_ALERT_OFF: "off",
+}
+_OPTION_TO_DRIPPING_ALERT: dict[str, PumpDrippingAlert] = {
+    v: k for k, v in _DRIPPING_ALERT_TO_OPTION.items()
 }
 
 
@@ -48,10 +61,13 @@ async def async_setup_entry(
             if isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).append(
-                    GardenaPumpOperatingModeSelect(coordinator, device)
+                entities_by_subentry_id.setdefault(sid, []).extend(
+                    [
+                        GardenaPumpOperatingModeSelect(coordinator, device),
+                        GardenaPumpDrippingAlert(coordinator, device),
+                    ]
                 )
-                _LOGGER.info("Adding operating mode select for device %s", device.id)
+                _LOGGER.info("Adding pump select entities for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -86,3 +102,35 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
             self._device.build_set_operating_mode_obj(mode),
         )
         _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)
+
+
+class GardenaPumpDrippingAlert(GardenaEntity, SelectEntity):
+    _attr_options = list(_OPTION_TO_DRIPPING_ALERT.keys())
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_dripping_alert"
+        self._attr_name = "Dripping Alert Timeout"
+
+    @property
+    def current_option(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        alert = device.dripping_alert
+        return _DRIPPING_ALERT_TO_OPTION.get(alert) if alert is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        alert = _OPTION_TO_DRIPPING_ALERT[option]
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_set_dripping_alert_obj(alert.value),
+        )
+        _LOGGER.info(
+            "Set dripping alert timeout for device %s to %s", self._device.id, option
+        )

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -139,7 +139,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaTemperatureSensor(GardenaEntity, SensorEntity):

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -57,7 +57,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaPowerSwitch(GardenaEntity, SwitchEntity):

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -50,7 +50,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaFirmwareUpdate(GardenaEntity, UpdateEntity):

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -61,7 +61,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaValve(GardenaEntity, ValveEntity):


### PR DESCRIPTION
## Summary

The core PR (adding this integration to home-assistant/core) got a Copilot review pass. Most of the findings apply equally here, since this is where the code originates from. One commit per bugfix, based on `main`:

- Build gateway WebSocket URLs with `yarl.URL.build` (IPv6 hosts produced invalid unbracketed URLs)
- Reconnect if either WebSocket worker exits, not just the reader
- Raise instead of silently no-opping when sending on a closed socket
- Raise `ConfigEntryNotReady` when the initial connect fails (previously an unreachable gateway was accepted as loaded)
- Run device-discovery listeners once immediately after subscribing, across all 9 platforms (previously only reacted to the *next* coordinator update, missing devices if discovery finished before the listener was registered)
- Unload platforms before disconnecting the coordinator
- Match existing entries by host across manual and zeroconf config flows (previously could create a duplicate entry for the same gateway)
- Drop devices missing from a fresh full discovery result (previously a device removed while disconnected would linger forever)
- Reflect gateway connection state in entity availability, not just the last-pushed per-device online flag
- Model the pump dripping alert as a select (3-value protocol enum), not a number that let you write arbitrary "seconds"
- Read the current coordinator device for mower activity instead of a stale captured reference, and preserve `MowerState.UNKNOWN` instead of mapping it to `LawnMowerActivity.ERROR`

Not changed (raised on the core PR, but these are intentional, not bugs):
- WebSocket transport ownership staying in the integration, not `gardena-smart-local-api` (the library is deliberately transport-agnostic)
- Factory reset on subentry delete (that's what excluding a device from the gateway actually is, same as the official app)

`main` has no test suite, so none was added here — this only touches `custom_components/`.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>