### PR TITLE
Build gateway WebSocket URLs with yarl.URL.build

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -7,6 +7,7 @@ import logging
 
 import aiohttp
 import voluptuous as vol
+from yarl import URL
 
 from homeassistant.config_entries import (
     ConfigEntry,
@@ -170,7 +171,7 @@ async def _async_try_connect(host: str, port: int, password: str) -> str | None:
     try:
         async with aiohttp.ClientSession() as session:
             async with session.ws_connect(
-                f"wss://{host}:{port}",
+                URL.build(scheme="wss", host=host, port=port),
                 ssl=ssl_context,
                 headers={"Authorization": f"Basic {auth_b64}"},
                 timeout=aiohttp.ClientTimeout(total=10),

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -8,6 +8,8 @@ import logging
 from dataclasses import dataclass
 
 import aiohttp
+from yarl import URL
+
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
@@ -62,7 +64,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self.host = host
         self.port = port
         self.password = password
-        self.uri = f"wss://{host}:{port}"
+        self.uri = URL.build(scheme="wss", host=host, port=port)
 
         auth_string = f"_:{password}"
         auth_bytes = auth_string.encode("utf-8")


### PR DESCRIPTION
f-string interpolation of host/port produces an invalid WebSocket URL for IPv6 literals (missing brackets), breaking connections to gateways reachable only via IPv6.