### PR TITLE
Reconnect if either WebSocket worker exits, not just the reader

### DIFF
--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -127,8 +127,14 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
                         await self._do_discovery()
 
-                        # Block until the reader exits (disconnect / error)
-                        await reader_task
+                        # Block until either worker exits (disconnect / error), then
+                        # re-raise its exception, if any, so we reconnect below.
+                        done, _pending = await asyncio.wait(
+                            (reader_task, consumer_task),
+                            return_when=asyncio.FIRST_COMPLETED,
+                        )
+                        for task in done:
+                            task.result()
                         _LOGGER.info(
                             "Disconnected from GARDENA smart Gateway, reconnecting"
                         )


### PR DESCRIPTION
Only the reader task was awaited before reconnecting, so a crash in the message consumer task went unnoticed and left the coordinator processing no more incoming events until the reader also happened to exit.