### PR TITLE
Raise instead of silently no-opping when sending on a closed socket

### DIFF
--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 
 import aiohttp
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
 
@@ -489,10 +490,9 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         wait_for_response_sec: float = 0,
     ) -> IngressMessageList:
         if not self._ws or self._ws.closed:
-            _LOGGER.error(
-                "Cannot send request to device %s: WebSocket not connected", device_id
+            raise HomeAssistantError(
+                f"Cannot send request to device {device_id}: WebSocket not connected"
             )
-            return IngressMessageList([])
 
         if wait_for_response_sec > 0:
             loop = asyncio.get_running_loop()


### PR DESCRIPTION
Callers awaited send_request expecting either a real reply or an exception; silently returning an empty reply list made a disconnected gateway look like it produced an empty (but valid) response.