### PR TITLE
Raise ConfigEntryNotReady when the initial connect fails

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -16,6 +16,7 @@ from homeassistant.config_entries import (
     SOURCE_IMPORT,
 )
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
 from homeassistant.const import (
@@ -84,7 +85,13 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         port=entry.data[CONF_PORT],
         password=entry.data[CONF_PASSWORD],
     )
-    await coordinator.async_connect()
+    try:
+        await coordinator.async_connect()
+    except Exception as err:
+        await coordinator.async_disconnect()
+        raise ConfigEntryNotReady(
+            f"Could not connect to GARDENA smart Gateway at {coordinator.uri}"
+        ) from err
     entry.runtime_data = coordinator
 
     async def _stop(_event: object) -> None:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -78,6 +78,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self._pending_replies: dict[str, asyncio.Future[Reply]] = {}
         self._includable_devices: dict[str, IncludableDeviceInfo] = {}
         self._includable_timeouts: dict[str, asyncio.TimerHandle] = {}
+        self._first_connect_result: asyncio.Future[None] | None = None
 
     async def _async_update_data(self) -> DeviceMap:
         return self._devices
@@ -90,9 +91,12 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
     async def async_connect(self) -> None:
         if self._ssl_context is None:
             self._ssl_context = get_default_no_verify_context()
+        self._first_connect_result = self.hass.loop.create_future()
         self._task = self.hass.async_create_background_task(
             self._ws_loop(), "gardena_smart_local_preview_websocket"
         )
+        async with asyncio.timeout(15):
+            await self._first_connect_result
 
     async def async_disconnect(self) -> None:
         for handle in self._includable_timeouts.values():
@@ -134,6 +138,12 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
                         await self._do_discovery()
 
+                        if (
+                            self._first_connect_result
+                            and not self._first_connect_result.done()
+                        ):
+                            self._first_connect_result.set_result(None)
+
                         # Block until either worker exits (disconnect / error), then
                         # re-raise its exception, if any, so we reconnect below.
                         done, _pending = await asyncio.wait(
@@ -148,8 +158,12 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
             except asyncio.CancelledError:
                 _LOGGER.debug("WebSocket loop cancelled")
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.cancel()
                 break
             except Exception as err:
+                if self._first_connect_result and not self._first_connect_result.done():
+                    self._first_connect_result.set_exception(err)
                 _LOGGER.error("WebSocket error: %s", err)
                 await asyncio.sleep(5)
             finally:


### PR DESCRIPTION
async_connect() spawned the WebSocket loop as a background task and returned immediately, so setup always succeeded even when the gateway was unreachable, and entities silently sat unavailable forever instead of Home Assistant retrying setup.