### PR TITLE
Run device-discovery listeners once immediately after subscribing

### DIFF
--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -54,7 +54,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaFrostWarningSensor(GardenaEntity, BinarySensorEntity):

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -73,7 +73,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaIdentifyButton(GardenaEntity, ButtonEntity):

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -56,7 +56,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaMower(GardenaEntity, LawnMowerEntity):

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -63,7 +63,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaButtonConfigTime(GardenaEntity, NumberEntity):

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -55,7 +55,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -139,7 +139,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaTemperatureSensor(GardenaEntity, SensorEntity):

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -57,7 +57,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaPowerSwitch(GardenaEntity, SwitchEntity):

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -50,7 +50,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaFirmwareUpdate(GardenaEntity, UpdateEntity):

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -61,7 +61,8 @@ async def async_setup_entry(
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
-    coordinator.async_add_listener(_add_new_devices)
+    entry.async_on_unload(coordinator.async_add_listener(_add_new_devices))
+    _add_new_devices()
 
 
 class GardenaValve(GardenaEntity, ValveEntity):


### PR DESCRIPTION
Entities were only ever added when the coordinator's data changed after platform setup, so devices already known at setup time (the common case, since discovery already ran during async_connect) did not get entities until the next discovery update. The listener was also never unregistered on unload.