### PR TITLE
Unload platforms before disconnecting the coordinator

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -173,6 +173,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    if not await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
+        return False
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     await coordinator.async_disconnect()
-    return await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
+    return True


### PR DESCRIPTION
Disconnecting first tore down the WebSocket while entities were still attached and could call coordinator.send_request during platform teardown, raising instead of unloading cleanly.