### PR TITLE
Match existing entries by host across manual and zeroconf config flows

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -47,6 +47,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             await self.async_set_unique_id(user_input[CONF_HOST])
             self._abort_if_unique_id_configured()
+            # A zeroconf-discovered entry for the same host would have a
+            # different (mDNS name based) unique_id, so also match on host.
+            self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
             error = await _async_try_connect(
                 user_input[CONF_HOST],
@@ -82,6 +85,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
 
         await self.async_set_unique_id(name)
         self._abort_if_unique_id_configured(updates={CONF_HOST: host, CONF_PORT: port})
+        # A manually-added entry for the same host would have a different
+        # (host based) unique_id, so also match on host.
+        self._async_abort_entries_match({CONF_HOST: host})
 
         self._discovered_host = host
         self._discovered_port = port


### PR DESCRIPTION
Manual setup keys unique_id on host while zeroconf keys it on the mDNS name, so the same gateway discovered both ways could be added twice as separate config entries.