### PR TITLE
Drop devices missing from a fresh full discovery result

### DIFF
--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -518,6 +518,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
 
     def _update_devices(self, devices: DeviceMap) -> None:
         try:
+            for device_id in self._devices.keys() - devices.keys():
+                _LOGGER.info(
+                    "Device %s no longer present in discovery, dropping", device_id
+                )
+                del self._devices[device_id]
             for device in devices.values():
                 self._update_device(device)
         except Exception as err:  # noqa: BLE001 - one bad device must not stop the discovery update


### PR DESCRIPTION
_update_devices only ever added or updated entries, so a device removed from the gateway (factory reset, exclusion) stayed in self._devices forever, keeping its entities and subentry around with stale data.

This is best-practise for Home Assistant integrations, also catched by their Copilot reviewer