### PR TITLE
Reflect gateway connection state in entity availability

### DIFF
--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -80,6 +80,11 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
     async def _async_update_data(self) -> DeviceMap:
         return self._devices
 
+    @property
+    def connected(self) -> bool:
+        """Return True if the WebSocket to the gateway is currently connected."""
+        return self._ws is not None and not self._ws.closed
+
     async def async_connect(self) -> None:
         if self._ssl_context is None:
             self._ssl_context = get_default_no_verify_context()
@@ -153,6 +158,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     if not fut.done():
                         fut.cancel()
                 self._pending_replies.clear()
+                # Let entities re-check availability now that we're disconnected.
+                self.async_update_listeners()
 
     async def _ws_reader(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         async for msg in ws:

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -48,6 +48,8 @@ class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):
 
     @property
     def available(self) -> bool:
+        if not self.coordinator.connected:
+            return False
         device = self.coordinator.data.get(self._device.id)
         return bool(device and device.is_online)
 


### PR DESCRIPTION
Entities only checked is_online in the last-known device data, so when the WebSocket to the gateway dropped, every entity kept showing its last state as available instead of becoming unavailable.