### PR TITLE
Model pump dripping alert as a select, not a number

### DIFF
--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -77,13 +77,10 @@ async def async_setup_entry(
             elif isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).extend(
-                    [
-                        GardenaPumpTurnOnPressure(coordinator, device),
-                        GardenaPumpDrippingAlert(coordinator, device),
-                    ]
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPumpTurnOnPressure(coordinator, device)
                 )
-                _LOGGER.info("Adding new pump number entities for device %s", device.id)
+                _LOGGER.info("Adding new pump number entity for device %s", device.id)
 
             new_valve_ids: list[int] = []
             for valve_id in getattr(device, "valve_ids", []):
@@ -200,42 +197,6 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
             "Set turn-on pressure for device %s to %s bar",
             self._device.id,
             value,
-        )
-
-
-class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
-    _attr_native_min_value = 0
-    _attr_native_max_value = 3600
-    _attr_native_step = 1
-    _attr_native_unit_of_measurement = UnitOfTime.SECONDS
-    _attr_mode = NumberMode.BOX
-    _attr_entity_category = EntityCategory.CONFIG
-
-    def __init__(
-        self,
-        coordinator: GardenaSmartLocalCoordinator,
-        device: Pump,
-    ) -> None:
-        super().__init__(coordinator, device)
-        self._attr_unique_id = f"{device.id}_dripping_alert"
-        self._attr_translation_key = "dripping_alert_timeout"
-
-    @property
-    def native_value(self) -> float | None:
-        device = self.coordinator.data.get(self._device.id)
-        if not device:
-            return None
-        return device.dripping_alert
-
-    async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_set_dripping_alert_obj(int(value)),
-        )
-        _LOGGER.info(
-            "Set dripping alert timeout for device %s to %s seconds",
-            self._device.id,
-            int(value),
         )
 
 

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -8,9 +8,13 @@ import logging
 from typing import ClassVar
 
 from gardena_smart_local_api.devices import Pump
-from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
+from gardena_smart_local_api.devices.irrigation import (
+    PumpDrippingAlert,
+    PumpOperatingMode,
+)
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
@@ -31,6 +35,15 @@ _OPTION_TO_MODE: dict[str, PumpOperatingMode] = {
     v: k for k, v in _MODE_TO_OPTION.items()
 }
 
+_DRIPPING_ALERT_TO_OPTION: dict[PumpDrippingAlert, str] = {
+    PumpDrippingAlert.MINUTES_60: "standard",
+    PumpDrippingAlert.MINUTES_2: "sensitive",
+    PumpDrippingAlert.DRIPPING_ALERT_OFF: "deactivated",
+}
+_OPTION_TO_DRIPPING_ALERT: dict[str, PumpDrippingAlert] = {
+    v: k for k, v in _DRIPPING_ALERT_TO_OPTION.items()
+}
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -49,10 +62,13 @@ async def async_setup_entry(
             if isinstance(device, Pump) and device.id not in known_devices:
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
-                entities_by_subentry_id.setdefault(sid, []).append(
-                    GardenaPumpOperatingModeSelect(coordinator, device)
+                entities_by_subentry_id.setdefault(sid, []).extend(
+                    [
+                        GardenaPumpOperatingModeSelect(coordinator, device),
+                        GardenaPumpDrippingAlert(coordinator, device),
+                    ]
                 )
-                _LOGGER.info("Adding operating mode select for device %s", device.id)
+                _LOGGER.info("Adding pump select entities for device %s", device.id)
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -87,3 +103,35 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
             self._device.build_set_operating_mode_obj(mode),
         )
         _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)
+
+
+class GardenaPumpDrippingAlert(GardenaEntity, SelectEntity):
+    _attr_options: ClassVar = list(_OPTION_TO_DRIPPING_ALERT.keys())
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        device: Pump,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._attr_unique_id = f"{device.id}_dripping_alert"
+        self._attr_translation_key = "dripping_alert"
+
+    @property
+    def current_option(self) -> str | None:
+        device = self.coordinator.data.get(self._device.id)
+        if not device:
+            return None
+        alert = device.dripping_alert
+        return _DRIPPING_ALERT_TO_OPTION.get(alert) if alert is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        alert = _OPTION_TO_DRIPPING_ALERT[option]
+        await self.coordinator.send_request(
+            self._device.id,
+            self._device.build_set_dripping_alert_obj(alert.value),
+        )
+        _LOGGER.info(
+            "Set dripping alert timeout for device %s to %s", self._device.id, option
+        )

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -31,9 +31,6 @@
       },
       "turn_on_pressure": {
         "name": "Einschaltdruck"
-      },
-      "dripping_alert_timeout": {
-        "name": "Tropfalarm-Zeitüberschreitung"
       }
     },
     "select": {
@@ -42,6 +39,14 @@
         "state": {
           "scheduled": "Geplant",
           "automatic": "Automatisch"
+        }
+      },
+      "dripping_alert": {
+        "name": "Tropfalarm",
+        "state": {
+          "standard": "Standard",
+          "sensitive": "Empfindlich",
+          "deactivated": "Deaktiviert"
         }
       }
     },

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -31,9 +31,6 @@
       },
       "turn_on_pressure": {
         "name": "Turn-on pressure"
-      },
-      "dripping_alert_timeout": {
-        "name": "Dripping alert timeout"
       }
     },
     "select": {
@@ -42,6 +39,14 @@
         "state": {
           "scheduled": "Scheduled",
           "automatic": "Automatic"
+        }
+      },
+      "dripping_alert": {
+        "name": "Dripping alert",
+        "state": {
+          "standard": "Standard",
+          "sensitive": "Sensitive",
+          "deactivated": "Deactivated"
         }
       }
     },


### PR DESCRIPTION
**⚠️ Breaking change:** the `dripping_alert` pump entity (number, in v0.1.0) becomes a select entity. Existing automations/dashboards referencing it as a number will break and need updating.

PumpDrippingAlert is a 3-value protocol enum (60 minutes / 2 minutes / off), not an arbitrary duration, so exposing it as a 0-3600s number let users pick values the gateway would silently reject or misinterpret.

Option labels (Standard/Sensitive/Deactivated) match the official GARDENA app's Leakage detection setting, which uses the same three names for these modes.