### PR TITLE
Add per-valve duration config and one-off override service

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,21 @@ gardena_smart_local_preview:
 
 After adding the configuration, restart Home Assistant.
 
+## Blueprints
+
+### Open Valve (with duration)
+
+The `open_valve` action lets you override a valve's configured duration per
+call, but Home Assistant has no built-in dashboard card that prompts for a
+service field on tap. This blueprint wraps `open_valve` in a script, whose
+more-info dialog does render the `duration` field as a form — so you can pick
+a one-off duration from the dashboard without writing a custom card.
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fcloudless-garden%2Fha-gardena-smart-local-preview%2Fmain%2Fblueprints%2Fscript%2Fgardena_smart_local_preview%2Fopen_valve_with_duration.yaml)
+
+After importing, create a script from the blueprint, pick the valve, and add
+the resulting script entity to your dashboard.
+
 ## Removal
 
 1. Go to **Settings → Devices & Services**

--- a/blueprints/script/gardena_smart_local_preview/open_valve_with_duration.yaml
+++ b/blueprints/script/gardena_smart_local_preview/open_valve_with_duration.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+blueprint:
+  name: Open GARDENA valve (with duration)
+  description: >-
+    Opens a GARDENA valve, optionally overriding its
+    configured duration for this run only.
+  domain: script
+  source_url: https://github.com/cloudless-garden/ha-gardena-smart-local-preview/blob/main/blueprints/script/gardena_smart_local_preview/open_valve_with_duration.yaml
+  input:
+    valve:
+      name: Valve
+      description: The valve to open.
+      selector:
+        entity:
+          filter:
+            integration: gardena_smart_local_preview
+            domain: valve
+
+fields:
+  duration:
+    name: Duration
+    description: How long to keep the valve open, in seconds.
+    required: false
+    example: 900
+    selector:
+      number:
+        min: 60
+        max: 10800
+        unit_of_measurement: s
+        mode: box
+
+sequence:
+  - action: gardena_smart_local_preview.open_valve
+    target:
+      entity_id: !input valve
+    data:
+      duration: "{{ duration | default(omit) }}"

--- a/custom_components/gardena_smart_local_preview/const.py
+++ b/custom_components/gardena_smart_local_preview/const.py
@@ -5,3 +5,7 @@
 DOMAIN = "gardena_smart_local_preview"
 
 DEFAULT_PORT = 8443
+DEFAULT_VALVE_DURATION_MINUTES = 30
+
+# Subentry data key holding {str(valve_id): minutes} for a device's valves
+CONF_VALVE_DURATIONS = "valve_durations"

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -6,22 +6,57 @@ from __future__ import annotations
 
 from gardena_smart_local_api.devices.device import Device
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import DOMAIN
+from .const import CONF_VALVE_DURATIONS, DEFAULT_VALVE_DURATION_MINUTES, DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
 
 
 def find_device_subentry_id(entry: ConfigEntry, device_id: str) -> str | None:
     return next(
         (
-            sid
-            for sid, se in entry.subentries.items()
+            subentry_id
+            for subentry_id, se in entry.subentries.items()
             if se.data.get("device_id") == device_id
         ),
         None,
+    )
+
+
+def get_valve_duration_minutes(
+    entry: ConfigEntry, device_id: str, valve_id: int
+) -> int:
+    # Falls back to the default for devices without a subentry, and for valves
+    # the user has never configured. Keys are strings because subentry data
+    # round-trips through JSON.
+    subentry_id = find_device_subentry_id(entry, device_id)
+    if subentry_id is None:
+        return DEFAULT_VALVE_DURATION_MINUTES
+    durations = entry.subentries[subentry_id].data.get(CONF_VALVE_DURATIONS, {})
+    minutes = durations.get(str(valve_id))
+    if not isinstance(minutes, int):
+        return DEFAULT_VALVE_DURATION_MINUTES
+    return minutes
+
+
+@callback
+def async_set_valve_duration_minutes(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_id: str,
+    valve_id: int,
+    minutes: int,
+) -> None:
+    subentry_id = find_device_subentry_id(entry, device_id)
+    if subentry_id is None:
+        return
+    subentry = entry.subentries[subentry_id]
+    durations = dict(subentry.data.get(CONF_VALVE_DURATIONS, {}))
+    durations[str(valve_id)] = minutes
+    hass.config_entries.async_update_subentry(
+        entry, subentry, data={**subentry.data, CONF_VALVE_DURATIONS: durations}
     )
 
 

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -159,8 +159,9 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
             request = self._device.build_set_button_config_time_obj(seconds)
         await self.coordinator.send_request(self._device.id, request)
         _LOGGER.info(
-            "Set button config time for device %s to %s minutes",
+            "Set button config time for device %s, valve %s to %s minutes",
             self._device.id,
+            self._valve_id,
             int(value),
         )
 

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -14,8 +14,14 @@ from homeassistant.const import EntityCategory, UnitOfPressure, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
+from .const import DEFAULT_VALVE_DURATION_MINUTES
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity, find_device_subentry_id
+from .entity import (
+    GardenaEntity,
+    async_set_valve_duration_minutes,
+    find_device_subentry_id,
+    get_valve_duration_minutes,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -32,6 +38,7 @@ async def async_setup_entry(
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
     known_button_time_valves: set[tuple[str, int]] = set()
+    known_valves: set[tuple[str, int]] = set()
 
     def _add_new_devices() -> None:
         if not coordinator.data:
@@ -43,6 +50,13 @@ async def async_setup_entry(
             if hasattr(device, "build_set_button_config_time_obj")
             for valve_id in device.valve_ids
         )
+
+        current_valves: set[tuple[str, int]] = set()
+        for device in coordinator.data.values():
+            for valve_id in getattr(device, "valve_ids", []):
+                current_valves.add((device.id, valve_id))
+        known_valves.intersection_update(current_valves)
+
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if hasattr(device, "build_set_button_config_time_obj"):
@@ -70,6 +84,26 @@ async def async_setup_entry(
                     ]
                 )
                 _LOGGER.info("Adding new pump number entities for device %s", device.id)
+
+            new_valve_ids: list[int] = []
+            for valve_id in getattr(device, "valve_ids", []):
+                if (device.id, valve_id) not in known_valves:
+                    new_valve_ids.append(valve_id)
+
+            if new_valve_ids:
+                sid = find_device_subentry_id(entry, device.id)
+                for valve_id in new_valve_ids:
+                    known_valves.add((device.id, valve_id))
+                    entities_by_subentry_id.setdefault(sid, []).append(
+                        GardenaValveDuration(coordinator, entry, device, valve_id)
+                    )
+                    _LOGGER.info(
+                        "Adding new valve duration entity for device %s, valve %s, "
+                        "default duration=%s minutes",
+                        device.id,
+                        valve_id,
+                        DEFAULT_VALVE_DURATION_MINUTES,
+                    )
         for sid, entities in entities_by_subentry_id.items():
             async_add_entities(entities, config_subentry_id=sid)
 
@@ -200,4 +234,56 @@ class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
             "Set dripping alert timeout for device %s to %s seconds",
             self._device.id,
             int(value),
+        )
+
+
+class GardenaValveDuration(GardenaEntity, NumberEntity):
+    _attr_native_min_value = 1
+    # Matches the ceiling the GARDENA app offers; how the firmware itself
+    # handles the maximum is not validated yet.
+    _attr_native_max_value = 180
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        entry: ConfigEntry,
+        device: Device,
+        valve_id: int,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._entry = entry
+        self._valve_id = valve_id
+        self._attr_unique_id = f"{device.id}_valve_{valve_id}_duration"
+        self._attr_name = (
+            f"Valve {valve_id + 1} Default Watering Duration"
+            if len(device.valve_ids) > 1
+            else "Default Watering Duration"
+        )
+        self._attr_icon = "mdi:timer-outline"
+
+    # Stored in the config subentry rather than read from the device, so it
+    # stays settable while the gateway or the device itself is unreachable.
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        return get_valve_duration_minutes(self._entry, self._device.id, self._valve_id)
+
+    async def async_set_native_value(self, value: float) -> None:
+        minutes = int(value)
+        async_set_valve_duration_minutes(
+            self.hass, self._entry, self._device.id, self._valve_id, minutes
+        )
+        self.async_write_ha_state()
+        _LOGGER.info(
+            "Set valve duration for device %s valve_id=%s to %s minutes",
+            self._device.id,
+            self._valve_id,
+            minutes,
         )

--- a/custom_components/gardena_smart_local_preview/services.yaml
+++ b/custom_components/gardena_smart_local_preview/services.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+open_valve:
+  target:
+    entity:
+      integration: gardena_smart_local_preview
+      domain: valve
+  fields:
+    duration:
+      required: false
+      example: 900
+      selector:
+        number:
+          min: 60
+          max: 10800
+          unit_of_measurement: s
+          mode: box

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -38,6 +38,18 @@
       }
     }
   },
+  "services": {
+    "open_valve": {
+      "name": "Ventil öffnen",
+      "description": "Öffnet ein Ventil, optional mit einer abweichenden Dauer nur für diesen Aufruf.",
+      "fields": {
+        "duration": {
+          "name": "Dauer",
+          "description": "Wie lange das Ventil geöffnet bleibt, in Sekunden (60-10800). Ohne Angabe wird die konfigurierte Dauer des Ventils verwendet."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -38,6 +38,18 @@
       }
     }
   },
+  "services": {
+    "open_valve": {
+      "name": "Open valve",
+      "description": "Opens a valve, optionally overriding its configured duration for this call only.",
+      "fields": {
+        "duration": {
+          "name": "Duration",
+          "description": "How long to keep the valve open, in seconds (60-10800). Defaults to the valve's configured duration if omitted."
+        }
+      }
+    }
+  },
   "config": {
     "step": {
       "user": {

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -7,10 +7,12 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import voluptuous as vol
 from gardena_smart_local_api.devices import Device
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
@@ -34,6 +36,17 @@ async def async_setup_entry(
 ) -> None:
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_valves: set[tuple[str, int]] = set()
+
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        "open_valve",
+        {
+            vol.Optional("duration"): vol.All(
+                vol.Coerce(int), vol.Range(min=60, max=10800)
+            )
+        },
+        "async_open_valve_for",
+    )
 
     def _add_new_devices() -> None:
         if not coordinator.data:
@@ -105,18 +118,23 @@ class GardenaValve(GardenaEntity, ValveEntity):
         return not is_opened
 
     async def async_open_valve(self, **kwargs: Any) -> None:
-        minutes = get_valve_duration_minutes(
-            self._entry, self._device.id, self._valve_id
-        )
+        await self.async_open_valve_for()
+
+    async def async_open_valve_for(self, duration: int | None = None) -> None:
+        if duration is None:
+            minutes = get_valve_duration_minutes(
+                self._entry, self._device.id, self._valve_id
+            )
+            duration = minutes * 60
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_open_valve_obj(self._valve_id, minutes * 60),
+            self._device.build_open_valve_obj(self._valve_id, duration),
         )
         _LOGGER.info(
-            "Opening valve %s valve_id=%s duration=%s minutes",
+            "Opening valve %s valve_id=%s duration=%s seconds",
             self._device.id,
             self._valve_id,
-            minutes,
+            duration,
         )
 
     async def async_close_valve(self, **kwargs: Any) -> None:

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -14,7 +14,11 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity, find_device_subentry_id
+from .entity import (
+    GardenaEntity,
+    find_device_subentry_id,
+    get_valve_duration_minutes,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -51,7 +55,7 @@ async def async_setup_entry(
                     continue
                 known_valves.add(key)
                 entities_by_subentry_id.setdefault(sid, []).append(
-                    GardenaValve(coordinator, device, valve_id)
+                    GardenaValve(coordinator, entry, device, valve_id)
                 )
                 _LOGGER.info(
                     "Adding new valve entity for device %s, valve %s",
@@ -69,10 +73,12 @@ class GardenaValve(GardenaEntity, ValveEntity):
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
+        entry: ConfigEntry,
         device: Device,
         valve_id: int = 0,
     ) -> None:
         super().__init__(coordinator, device)
+        self._entry = entry
         self._valve_id = valve_id
         self._attr_unique_id = f"{device.id}_valve_{valve_id}"
         self._attr_name = f"Valve {valve_id + 1}" if len(device.valve_ids) > 1 else None
@@ -99,11 +105,19 @@ class GardenaValve(GardenaEntity, ValveEntity):
         return not is_opened
 
     async def async_open_valve(self, **kwargs: Any) -> None:
+        minutes = get_valve_duration_minutes(
+            self._entry, self._device.id, self._valve_id
+        )
         await self.coordinator.send_request(
             self._device.id,
-            self._device.build_open_valve_obj(self._valve_id, 1800),
+            self._device.build_open_valve_obj(self._valve_id, minutes * 60),
         )
-        _LOGGER.info("Opening valve %s valve_id=%s", self._device.id, self._valve_id)
+        _LOGGER.info(
+            "Opening valve %s valve_id=%s duration=%s minutes",
+            self._device.id,
+            self._valve_id,
+            minutes,
+        )
 
     async def async_close_valve(self, **kwargs: Any) -> None:
         await self.coordinator.send_request(


### PR DESCRIPTION
valve.open_valve hardcoded a 30-minute duration; the library already supports a configurable duration_seconds but the integration never exposed it (#82). Adds one config number entity per valve, defaulting to 30 minutes, stored in the device's config subentry so it persists and is removed with the device.

Also adds gardena_smart_local_preview.open_valve for automations/scripts that need a one-off duration without changing the stored default.