### PR TITLE
Fix ruff lint errors surfaced by ruff 0.16 upgrade

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -5,28 +5,26 @@
 import logging
 from types import MappingProxyType
 
+import homeassistant.helpers.config_validation as cv
 import voluptuous as vol
-
-
 from homeassistant.config_entries import (
+    SIGNAL_CONFIG_ENTRY_CHANGED,
+    SOURCE_IMPORT,
     ConfigEntry,
     ConfigEntryChange,
     ConfigSubentry,
-    SIGNAL_CONFIG_ENTRY_CHANGED,
-    SOURCE_IMPORT,
+)
+from homeassistant.const import (
+    CONF_HOST,
+    CONF_PASSWORD,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STOP,
+    Platform,
 )
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
-from homeassistant.const import (
-    CONF_HOST,
-    CONF_PORT,
-    CONF_PASSWORD,
-    EVENT_HOMEASSISTANT_STOP,
-    Platform,
-)
-import homeassistant.helpers.config_validation as cv
 
 from . import config_flow as config_flow
 from .const import DEFAULT_PORT, DOMAIN

--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import logging
 
+from gardena_smart_local_api.devices.device import Device
 from homeassistant.components.binary_sensor import (
     BinarySensorDeviceClass,
     BinarySensorEntity,
@@ -16,7 +17,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices.device import Device
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -6,16 +6,16 @@ from __future__ import annotations
 
 import logging
 
+from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices.device import Device
 from homeassistant.components.button import ButtonEntity
-from homeassistant.const import EntityCategory
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices.device import Device
-from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -7,8 +7,6 @@ import logging
 
 import aiohttp
 import voluptuous as vol
-from yarl import URL
-
 from homeassistant.config_entries import (
     ConfigEntry,
     ConfigFlow,
@@ -16,11 +14,12 @@ from homeassistant.config_entries import (
     ConfigSubentryFlow,
     SubentryFlowResult,
 )
+from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.core import callback
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
-from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.ssl import get_default_no_verify_context
+from yarl import URL
 
 from .const import DEFAULT_PORT, DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
@@ -169,14 +168,16 @@ async def _async_try_connect(host: str, port: int, password: str) -> str | None:
     auth_b64 = base64.b64encode(f"_:{password}".encode()).decode("ascii")
 
     try:
-        async with aiohttp.ClientSession() as session:
-            async with session.ws_connect(
+        async with (
+            aiohttp.ClientSession() as session,
+            session.ws_connect(
                 URL.build(scheme="wss", host=host, port=port),
                 ssl=ssl_context,
                 headers={"Authorization": f"Basic {auth_b64}"},
                 timeout=aiohttp.ClientTimeout(total=10),
-            ) as ws:
-                await ws.close()
+            ) as ws,
+        ):
+            await ws.close()
     except aiohttp.WSServerHandshakeError as err:
         if err.status == 401:
             return "invalid_auth"

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -8,13 +8,6 @@ import logging
 from dataclasses import dataclass
 
 import aiohttp
-from yarl import URL
-
-from homeassistant.core import HomeAssistant, callback
-from homeassistant.exceptions import HomeAssistantError
-from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
-from homeassistant.util.ssl import get_default_no_verify_context
-
 from gardena_smart_local_api.devices import (
     Device,
     DeviceMap,
@@ -23,13 +16,18 @@ from gardena_smart_local_api.devices import (
     create_devices_from_messages,
 )
 from gardena_smart_local_api.messages import (
-    Reply,
-    Event,
     EgressMessageList,
+    Event,
     IngressMessageList,
+    Reply,
 )
 from gardena_smart_local_api.sgtin96 import SGTIN96Info
 from gardena_smart_local_api.utils import deep_merge_dict
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
+from homeassistant.util.ssl import get_default_no_verify_context
+from yarl import URL
 
 INCLUDE_REPLY_TIMEOUT = 10
 EXCLUDE_REPLY_TIMEOUT = 10
@@ -116,46 +114,46 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             consumer_task = None
             try:
                 _LOGGER.debug("Connecting to GARDENA smart Gateway at %s", self.uri)
-                async with aiohttp.ClientSession() as session:
-                    async with session.ws_connect(
+                async with (
+                    aiohttp.ClientSession() as session,
+                    session.ws_connect(
                         self.uri,
                         ssl=self._ssl_context,
                         heartbeat=30,
                         headers={"Authorization": f"Basic {self.auth_b64}"},
-                    ) as ws:
-                        self._ws = ws
-                        _LOGGER.info(
-                            "Connected to GARDENA smart Gateway at %s", self.uri
-                        )
+                    ) as ws,
+                ):
+                    self._ws = ws
+                    _LOGGER.info("Connected to GARDENA smart Gateway at %s", self.uri)
 
-                        reader_task = self.hass.async_create_background_task(
-                            self._ws_reader(ws),
-                            "gardena_smart_local_preview_ws_reader",
-                        )
-                        consumer_task = self.hass.async_create_background_task(
-                            self._msg_consumer(),
-                            "gardena_smart_local_preview_msg_consumer",
-                        )
+                    reader_task = self.hass.async_create_background_task(
+                        self._ws_reader(ws),
+                        "gardena_smart_local_preview_ws_reader",
+                    )
+                    consumer_task = self.hass.async_create_background_task(
+                        self._msg_consumer(),
+                        "gardena_smart_local_preview_msg_consumer",
+                    )
 
-                        await self._do_discovery()
+                    await self._do_discovery()
 
-                        if (
-                            self._first_connect_result
-                            and not self._first_connect_result.done()
-                        ):
-                            self._first_connect_result.set_result(None)
+                    if (
+                        self._first_connect_result
+                        and not self._first_connect_result.done()
+                    ):
+                        self._first_connect_result.set_result(None)
 
-                        # Block until either worker exits (disconnect / error), then
-                        # re-raise its exception, if any, so we reconnect below.
-                        done, _pending = await asyncio.wait(
-                            (reader_task, consumer_task),
-                            return_when=asyncio.FIRST_COMPLETED,
-                        )
-                        for task in done:
-                            task.result()
-                        _LOGGER.info(
-                            "Disconnected from GARDENA smart Gateway, reconnecting"
-                        )
+                    # Block until either worker exits (disconnect / error), then
+                    # re-raise its exception, if any, so we reconnect below.
+                    done, _pending = await asyncio.wait(
+                        (reader_task, consumer_task),
+                        return_when=asyncio.FIRST_COMPLETED,
+                    )
+                    for task in done:
+                        task.result()
+                    _LOGGER.info(
+                        "Disconnected from GARDENA smart Gateway, reconnecting"
+                    )
 
             except asyncio.CancelledError:
                 _LOGGER.debug("WebSocket loop cancelled")

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -160,7 +160,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 if self._first_connect_result and not self._first_connect_result.done():
                     self._first_connect_result.cancel()
                 break
-            except Exception as err:
+            except Exception as err:  # noqa: BLE001 - any transport error must trigger a reconnect
                 if self._first_connect_result and not self._first_connect_result.done():
                     self._first_connect_result.set_exception(err)
                 _LOGGER.error("WebSocket error: %s", err)
@@ -172,8 +172,8 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                         task.cancel()
                         try:
                             await task
-                        except (asyncio.CancelledError, Exception):
-                            pass
+                        except (asyncio.CancelledError, Exception) as err:  # noqa: BLE001 - best-effort cleanup, cancellation is expected
+                            _LOGGER.debug("Error awaiting cancelled task: %s", err)
                 # Cancel any pending reply futures so waiters don't hang
                 for fut in self._pending_replies.values():
                     if not fut.done():
@@ -204,7 +204,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 raw = await self._msg_queue.get()
                 try:
                     messages = IngressMessageList.model_validate_json(raw)
-                except Exception:
+                except Exception:  # noqa: BLE001 - malformed message, ignore and keep reading
                     _LOGGER.debug(
                         "Ignoring non-list message from GARDENA smart Gateway: %s", raw
                     )
@@ -297,7 +297,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             if updated:
                 self.async_set_updated_data(self._devices)
 
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - one bad message must not crash the coordinator
             _LOGGER.warning("Error handling messages (may be non-critical): %s", err)
 
     def _expire_includable(self, instance_id: str) -> None:
@@ -385,7 +385,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout waiting for inclusion reply for %s", device_id)
             return None
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - report failure to the config flow instead of raising
             _LOGGER.error("Error including device %s: %s", instance_id, err)
             return None
 
@@ -410,7 +410,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     # point; the caller schedules async_set_updated_data as a
                     # task so it runs after _async_finish_flow adds the subentry.
                     await self._do_discovery(broadcast=False)
-                except Exception as err:
+                except Exception as err:  # noqa: BLE001 - inclusion already succeeded, don't fail it over this
                     _LOGGER.warning("Re-discovery after inclusion failed: %s", err)
                     return None
                 if info.device_id not in self._devices:
@@ -447,7 +447,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         except asyncio.TimeoutError:
             _LOGGER.error("Timeout waiting for exclusion reply for %s", device_id)
             return False
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - report failure to the config flow instead of raising
             _LOGGER.error("Error excluding device %s: %s", device_id, err)
             return False
 
@@ -475,7 +475,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         except asyncio.TimeoutError:
             _LOGGER.debug("Timeout refreshing firmware state for %s", device_id)
             return
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - best-effort refresh, must not disrupt the coordinator
             _LOGGER.debug("Error refreshing firmware state for %s: %s", device_id, err)
             return
 
@@ -507,7 +507,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         try:
             for device in devices.values():
                 self._update_device(device)
-        except Exception as err:
+        except Exception as err:  # noqa: BLE001 - one bad device must not stop the discovery update
             _LOGGER.warning("Failed to update devices: %s", err)
 
     async def send_request(

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from gardena_smart_local_api.devices.device import Device
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import callback
 from homeassistant.helpers import device_registry as dr
@@ -11,7 +12,6 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import GardenaSmartLocalCoordinator
-from gardena_smart_local_api.devices.device import Device
 
 
 def find_device_subentry_id(entry: ConfigEntry, device_id: str) -> str | None:

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 import logging
 
 from gardena_smart_local_api.devices import Device, MowerState
-
 from homeassistant.components.lawn_mower import (
     LawnMowerActivity,
     LawnMowerEntity,

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -6,16 +6,16 @@ from __future__ import annotations
 
 import logging
 
+from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices.device import Device
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory, UnitOfTime, UnitOfPressure
+from homeassistant.const import EntityCategory, UnitOfPressure, UnitOfTime
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices.device import Device
-from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -93,7 +93,7 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         seconds = device.button_config_time
         if seconds is None:
             return None
-        return int(round(seconds / 60))
+        return round(seconds / 60)
 
     async def async_set_native_value(self, value: float) -> None:
         await self.coordinator.send_request(

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import logging
 
+from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -13,8 +15,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices import Pump
-from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from gardena_smart_local_api.devices import Pump
 from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
@@ -60,7 +61,7 @@ async def async_setup_entry(
 
 
 class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
-    _attr_options = list(_OPTION_TO_MODE.keys())
+    _attr_options: ClassVar = list(_OPTION_TO_MODE.keys())
 
     def __init__(
         self,

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import ClassVar
 
 from gardena_smart_local_api.devices import Pump
 from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
@@ -408,7 +409,7 @@ class GardenaScheduleCountSensor(GardenaEntity, SensorEntity):
 
 class GardenaFirmwareUpdateStateSensor(GardenaEntity, SensorEntity):
     _attr_device_class = SensorDeviceClass.ENUM
-    _attr_options = [str(state) for state in FirmwareUpdateState]
+    _attr_options: ClassVar = [str(state) for state in FirmwareUpdateState]
 
     def __init__(
         self,

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 
 import logging
 
+from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -16,18 +18,16 @@ from homeassistant.const import (
     LIGHT_LUX,
     PERCENTAGE,
     EntityCategory,
-    UnitOfTemperature,
     UnitOfPressure,
-    UnitOfVolumeFlowRate,
+    UnitOfTemperature,
     UnitOfVolume,
+    UnitOfVolumeFlowRate,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
-from gardena_smart_local_api.devices import Pump
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from gardena_smart_local_api.devices import PowerAdapter, Pump
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -14,7 +15,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices import PowerAdapter, Pump
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
 from homeassistant.components.update import (
     UpdateDeviceClass,
     UpdateEntity,
@@ -18,7 +19,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+from gardena_smart_local_api.devices import Device
 from homeassistant.components.valve import ValveEntity, ValveEntityFeature
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -14,7 +15,6 @@ from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import GardenaEntity, find_device_subentry_id
-from gardena_smart_local_api.devices import Device
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
CI's ruff-action installs the latest ruff unpinned. 0.16 expanded the default rule set (I001, BLE001, S110, RUF012, RUF046), turning main's CI red without any code change. Reorders imports, adds targeted noqa comments for intentional broad excepts in the websocket reconnect loop, and fixes the two genuinely real issues (mutable class defaults, redundant int cast).