### PR TITLE
Await gateway reply for all commands, defer UI update until confirmed

### DIFF
--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -88,10 +88,7 @@ class GardenaIdentifyButton(GardenaEntity, ButtonEntity):
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     async def async_press(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_identify_obj(),
-        )
+        await self._send_confirmed_command(self._device.build_identify_obj())
         _LOGGER.info("Sent identify request for device %s", self._device.id)
 
 
@@ -103,9 +100,8 @@ class GardenaPumpResetFlowButton(GardenaEntity, ButtonEntity):
         self._attr_entity_category = EntityCategory.CONFIG
 
     async def async_press(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_reset_flow_resettable_obj(),
+        await self._send_confirmed_command(
+            self._device.build_reset_flow_resettable_obj()
         )
         _LOGGER.info("Reset resettable flow for device %s", self._device.id)
 
@@ -118,9 +114,8 @@ class GardenaPumpResetValveErrorsButton(GardenaEntity, ButtonEntity):
         self._attr_entity_category = EntityCategory.CONFIG
 
     async def async_press(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_reset_all_valve_errors_obj(),
+        await self._send_confirmed_command(
+            self._device.build_reset_all_valve_errors_obj()
         )
         _LOGGER.info("Reset valve errors for device %s", self._device.id)
 
@@ -133,9 +128,8 @@ class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
         self._attr_entity_category = EntityCategory.CONFIG
 
     async def async_press(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_reset_outlet_temperature_min_max_obj(),
+        await self._send_confirmed_command(
+            self._device.build_reset_outlet_temperature_min_max_obj()
         )
         _LOGGER.info("Reset temperature min/max for device %s", self._device.id)
 
@@ -153,8 +147,5 @@ class GardenaClearSchedulesButton(GardenaEntity, ButtonEntity):
         self._attr_unique_id = f"{device.id}_clear_schedules"
 
     async def async_press(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_clear_schedules_obj(),
-        )
+        await self._send_confirmed_command(self._device.build_clear_schedules_obj())
         _LOGGER.info("Cleared schedules for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -34,6 +34,7 @@ EXCLUDE_REPLY_TIMEOUT = 10
 INCLUDABLE_DEVICE_HEARTBEAT_TIMEOUT = 25
 INCLUSION_TIMEOUT = 30
 FIRMWARE_REPLY_TIMEOUT = 10
+COMMAND_REPLY_TIMEOUT = 10
 
 
 @dataclass
@@ -78,6 +79,14 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         self._includable_devices: dict[str, IncludableDeviceInfo] = {}
         self._includable_timeouts: dict[str, asyncio.TimerHandle] = {}
         self._first_connect_result: asyncio.Future[None] | None = None
+        # Devices with a command reply still outstanding. While a device is
+        # in here, incoming Events for it are merged into self._devices but
+        # not broadcast — the gateway reports state changes (e.g. a valve
+        # opening) across several back-to-back frames, each of which would
+        # otherwise flash an intermediate state in the UI. The final,
+        # confirmed state is broadcast once the reply for the last
+        # outstanding command on that device arrives (see send_request).
+        self._pending_reply_devices: dict[str, int] = {}
 
     async def _async_update_data(self) -> DeviceMap:
         return self._devices
@@ -179,6 +188,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                     if not fut.done():
                         fut.cancel()
                 self._pending_replies.clear()
+                self._pending_reply_devices.clear()
                 # Let entities re-check availability now that we're disconnected.
                 self.async_update_listeners()
 
@@ -258,7 +268,7 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
         try:
             _LOGGER.debug("Handling %d message(s)", len(messages))
 
-            updated = False
+            updated_device_ids: set[str] = set()
 
             for msg in messages:
                 if isinstance(msg, Event):
@@ -288,13 +298,16 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                                     device_id,
                                     device.is_online,
                                 )
-                            updated = True
+                            updated_device_ids.add(device_id)
                     else:
                         _LOGGER.debug(
                             "Event does not have device ID, ignoring: %s", msg
                         )
 
-            if updated:
+            # Devices with a command in flight are merged above but not
+            # broadcast yet — send_request() flushes them once the reply for
+            # that command confirms the settled state.
+            if updated_device_ids - self._pending_reply_devices.keys():
                 self.async_set_updated_data(self._devices)
 
         except Exception as err:  # noqa: BLE001 - one bad message must not crash the coordinator
@@ -530,19 +543,32 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
                 rid: loop.create_future() for rid in pending_ids
             }
             self._pending_replies.update(futures)
-
-            await self._ws.send_str(request.model_dump_json())
-            _LOGGER.debug("Sent request to device %s: %s", device_id, request)
+            self._pending_reply_devices[device_id] = (
+                self._pending_reply_devices.get(device_id, 0) + 1
+            )
 
             try:
-                async with asyncio.timeout(wait_for_response_sec):
-                    replies = await asyncio.gather(*futures.values())
-            except asyncio.TimeoutError:
-                for rid in pending_ids:
-                    self._pending_replies.pop(rid, None)
-                raise
+                await self._ws.send_str(request.model_dump_json())
+                _LOGGER.debug("Sent request to device %s: %s", device_id, request)
 
-            return IngressMessageList(list(replies))
+                try:
+                    async with asyncio.timeout(wait_for_response_sec):
+                        replies = await asyncio.gather(*futures.values())
+                except asyncio.TimeoutError:
+                    for rid in pending_ids:
+                        self._pending_replies.pop(rid, None)
+                    raise
+
+                return IngressMessageList(list(replies))
+            finally:
+                remaining = self._pending_reply_devices.get(device_id, 1) - 1
+                if remaining <= 0:
+                    self._pending_reply_devices.pop(device_id, None)
+                    # Last outstanding command for this device settled —
+                    # broadcast the confirmed state now.
+                    self.async_set_updated_data(self._devices)
+                else:
+                    self._pending_reply_devices[device_id] = remaining
 
         await self._ws.send_str(request.model_dump_json())
         _LOGGER.debug("Sent request to device %s: %s", device_id, request)

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -5,13 +5,15 @@
 from __future__ import annotations
 
 from gardena_smart_local_api.devices.device import Device
+from gardena_smart_local_api.messages import EgressMessageList, Reply
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_VALVE_DURATIONS, DEFAULT_VALVE_DURATION_MINUTES, DOMAIN
-from .coordinator import GardenaSmartLocalCoordinator
+from .coordinator import COMMAND_REPLY_TIMEOUT, GardenaSmartLocalCoordinator
 
 
 def find_device_subentry_id(entry: ConfigEntry, device_id: str) -> str | None:
@@ -107,3 +109,28 @@ class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):
                 self.device_entry.id, sw_version=device.software_version
             )
         super()._handle_coordinator_update()
+
+    async def _send_confirmed_command(
+        self, request: EgressMessageList, timeout_sec: float = COMMAND_REPLY_TIMEOUT
+    ) -> None:
+        """Send a command and wait for the gateway to confirm it landed.
+
+        Raises HomeAssistantError on timeout or rejection instead of letting
+        the entity's state flip based on unconfirmed intermediate frames.
+        """
+        try:
+            replies = await self.coordinator.send_request(
+                self._device.id, request, wait_for_response_sec=timeout_sec
+            )
+        except TimeoutError as err:
+            raise HomeAssistantError(
+                f"Timed out waiting for the GARDENA smart Gateway to confirm "
+                f"the command for device {self._device.id}"
+            ) from err
+
+        for msg in replies:
+            if isinstance(msg, Reply) and not msg.success:
+                raise HomeAssistantError(
+                    f"GARDENA smart Gateway rejected the command for device "
+                    f"{self._device.id}"
+                )

--- a/custom_components/gardena_smart_local_preview/lawn_mower.py
+++ b/custom_components/gardena_smart_local_preview/lawn_mower.py
@@ -102,25 +102,18 @@ class GardenaMower(GardenaEntity, LawnMowerEntity):
         return None
 
     async def async_start_mowing(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_start_mowing_obj(28800),  # 8 hours
+        await self._send_confirmed_command(
+            self._device.build_start_mowing_obj(28800)  # 8 hours
         )
         _LOGGER.info("Start mowing with %s", self._device.id)
 
     async def async_dock(self) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_stop_mowing_obj(),
-        )
+        await self._send_confirmed_command(self._device.build_stop_mowing_obj())
         _LOGGER.info("Stop mowing with %s", self._device.id)
 
     async def async_pause(self) -> None:
         if hasattr(self._device, "build_pause_mowing_obj"):
-            await self.coordinator.send_request(
-                self._device.id,
-                self._device.build_pause_mowing_obj(),
-            )
+            await self._send_confirmed_command(self._device.build_pause_mowing_obj())
             _LOGGER.info("Pause mowing with %s", self._device.id)
         else:
             _LOGGER.warning("Pause not supported for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -155,7 +155,7 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
             )
         else:
             request = self._device.build_set_button_config_time_obj(seconds)
-        await self.coordinator.send_request(self._device.id, request)
+        await self._send_confirmed_command(request)
         _LOGGER.info(
             "Set button config time for device %s, valve %s to %s minutes",
             self._device.id,
@@ -189,9 +189,8 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
         return device.turn_on_pressure
 
     async def async_set_native_value(self, value: float) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_set_turn_on_pressure_obj(value),
+        await self._send_confirmed_command(
+            self._device.build_set_turn_on_pressure_obj(value)
         )
         _LOGGER.info(
             "Set turn-on pressure for device %s to %s bar",

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -98,9 +98,8 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         mode = _OPTION_TO_MODE[option]
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_set_operating_mode_obj(mode),
+        await self._send_confirmed_command(
+            self._device.build_set_operating_mode_obj(mode)
         )
         _LOGGER.info("Set operating mode for device %s to %s", self._device.id, option)
 
@@ -128,9 +127,8 @@ class GardenaPumpDrippingAlert(GardenaEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         alert = _OPTION_TO_DRIPPING_ALERT[option]
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_set_dripping_alert_obj(alert.value),
+        await self._send_confirmed_command(
+            self._device.build_set_dripping_alert_obj(alert.value)
         )
         _LOGGER.info(
             "Set dripping alert timeout for device %s to %s", self._device.id, option

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -80,17 +80,13 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
         return device.is_output_enabled
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_enable_output_obj(DEFAULT_ON_DURATION_SECONDS),
+        await self._send_confirmed_command(
+            self._device.build_enable_output_obj(DEFAULT_ON_DURATION_SECONDS)
         )
         _LOGGER.info("Turning on switch %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_disable_output_obj(),
-        )
+        await self._send_confirmed_command(self._device.build_disable_output_obj())
         _LOGGER.info("Turning off switch %s", self._device.id)
 
 
@@ -112,15 +108,11 @@ class GardenaPumpSwitch(GardenaEntity, SwitchEntity):
         return device.is_running
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_start_obj(DEFAULT_ON_DURATION_SECONDS),
+        await self._send_confirmed_command(
+            self._device.build_start_obj(DEFAULT_ON_DURATION_SECONDS)
         )
         _LOGGER.info("Turning on pump %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_stop_obj(),
-        )
+        await self._send_confirmed_command(self._device.build_stop_obj())
         _LOGGER.info("Turning off pump %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -126,8 +126,7 @@ class GardenaFirmwareUpdate(GardenaEntity, UpdateEntity):
         device = self.coordinator.data.get(self._device.id)
         if device:
             self._held_latest_version = device.available_software_version
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_install_firmware_update_obj(),
+        await self._send_confirmed_command(
+            self._device.build_install_firmware_update_obj()
         )
         _LOGGER.info("Sent firmware install request for device %s", self._device.id)

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -130,9 +130,8 @@ class GardenaValve(GardenaEntity, ValveEntity):
                 self._entry, self._device.id, self._valve_id
             )
             duration = minutes * 60
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_open_valve_obj(self._valve_id, duration),
+        await self._send_confirmed_command(
+            self._device.build_open_valve_obj(self._valve_id, duration)
         )
         _LOGGER.info(
             "Opening valve %s valve_id=%s duration=%s seconds",
@@ -142,8 +141,7 @@ class GardenaValve(GardenaEntity, ValveEntity):
         )
 
     async def async_close_valve(self, **kwargs: Any) -> None:
-        await self.coordinator.send_request(
-            self._device.id,
-            self._device.build_close_valve_obj(self._valve_id),
+        await self._send_confirmed_command(
+            self._device.build_close_valve_obj(self._valve_id)
         )
         _LOGGER.info("Closing valve %s valve_id=%s", self._device.id, self._valve_id)


### PR DESCRIPTION
## Summary
- Gateway reports state changes across several back-to-back WebSocket frames, each triggering its own entity update — flashing an intermediate state before settling. This started as a valve-only fix, now generalized to every command-issuing entity (switch, select, number, button, update, lawn mower, valve) via a shared `GardenaEntity._send_confirmed_command` helper.
- `Reply.success` confirms actual command execution (not just receipt), so buffer per-device events while a command is in flight and broadcast the confirmed state once the reply lands.
- Rejected/timed-out commands now surface as errors instead of failing silently, across all platforms.

Closes #66