### PR TITLE
Update gardena-smart-local-api to version 0.1.2

### DIFF
--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -6,7 +6,7 @@
   "documentation": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview",
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
-  "requirements": ["gardena-smart-local-api==0.1.1"],
+  "requirements": ["gardena-smart-local-api==0.1.2"],
   "version": "0.1.0",
   "zeroconf": ["_gardena-smart._tcp.local."]
 }


### PR DESCRIPTION
Identify support for Gen2 devices, fix for Gen1 is_valve_open
not detecting scheduled watering.