### PR TITLE
Add release-notes categories for breaking changes, bugs, and enhancements

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+changelog:
+  categories:
+    - title: ⚠️ Breaking Changes
+      labels:
+        - breaking-change
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -7,6 +7,12 @@ changelog:
     - title: ⚠️ Breaking Changes
       labels:
         - breaking-change
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+    - title: ✨ Enhancements
+      labels:
+        - enhancement
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
GitHub's auto-generated release notes (`generate_release_notes: true` in the release workflow) dumped everything into one flat list. This adds label-based categories so the release page groups PRs into:

- ⚠️ Breaking Changes (`breaking-change`)
- 🐛 Bug Fixes (`bug`)
- ✨ Enhancements (`enhancement`)
- Other Changes (everything else)

Needed for #79, which replaces the `dripping_alert` number entity (shipped in v0.1.0) with a select entity.