### PR TITLE
Add translation_key to entities, translate names into German

### DIFF
--- a/custom_components/gardena_smart_local_preview/binary_sensor.py
+++ b/custom_components/gardena_smart_local_preview/binary_sensor.py
@@ -66,7 +66,7 @@ class GardenaFrostWarningSensor(GardenaEntity, BinarySensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_frost_warning"
-        self._attr_name = "Frost Warning"
+        self._attr_translation_key = "frost_warning"
         self._attr_device_class = BinarySensorDeviceClass.COLD
         self._attr_icon = "mdi:snowflake-alert"
 

--- a/custom_components/gardena_smart_local_preview/button.py
+++ b/custom_components/gardena_smart_local_preview/button.py
@@ -83,7 +83,7 @@ class GardenaIdentifyButton(GardenaEntity, ButtonEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_identify"
-        self._attr_name = "Identify"
+        self._attr_translation_key = "identify"
         self._attr_icon = "mdi:crosshairs-gps"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
@@ -99,7 +99,7 @@ class GardenaPumpResetFlowButton(GardenaEntity, ButtonEntity):
     def __init__(self, coordinator: GardenaSmartLocalCoordinator, device: Pump) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_reset_flow"
-        self._attr_name = "Reset Resettable Flow"
+        self._attr_translation_key = "reset_resettable_flow"
         self._attr_entity_category = EntityCategory.CONFIG
 
     async def async_press(self) -> None:
@@ -114,7 +114,7 @@ class GardenaPumpResetValveErrorsButton(GardenaEntity, ButtonEntity):
     def __init__(self, coordinator: GardenaSmartLocalCoordinator, device: Pump) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_reset_valve_errors"
-        self._attr_name = "Reset Valve Errors"
+        self._attr_translation_key = "reset_valve_errors"
         self._attr_entity_category = EntityCategory.CONFIG
 
     async def async_press(self) -> None:
@@ -129,7 +129,7 @@ class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
     def __init__(self, coordinator: GardenaSmartLocalCoordinator, device: Pump) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_reset_temperature_min_max"
-        self._attr_name = "Reset Temperature Min/Max"
+        self._attr_translation_key = "reset_temperature_min_max"
         self._attr_entity_category = EntityCategory.CONFIG
 
     async def async_press(self) -> None:
@@ -143,8 +143,7 @@ class GardenaPumpResetTemperatureMinMaxButton(GardenaEntity, ButtonEntity):
 class GardenaClearSchedulesButton(GardenaEntity, ButtonEntity):
     _attr_entity_category = EntityCategory.CONFIG
     _attr_entity_registry_enabled_default = False
-    _attr_has_entity_name = True
-    _attr_name = "Clear Schedules"
+    _attr_translation_key = "clear_schedules"
     _attr_icon = "mdi:delete-alert-outline"
 
     def __init__(

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -131,9 +131,10 @@ class GardenaButtonConfigTime(GardenaEntity, NumberEntity):
         suffix = f"_{valve_id}" if multi_valve else ""
         self._attr_unique_id = f"{device.id}_button_config_time{suffix}"
         if multi_valve:
-            self._attr_name = f"Button Watering Duration {valve_id + 1}"
+            self._attr_translation_key = "button_watering_duration_numbered"
+            self._attr_translation_placeholders = {"number": str(valve_id + 1)}
         else:
-            self._attr_name = "Button Watering Duration"
+            self._attr_translation_key = "button_watering_duration"
         self._attr_icon = "mdi:timer-outline"
 
     @property
@@ -181,7 +182,7 @@ class GardenaPumpTurnOnPressure(GardenaEntity, NumberEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_turn_on_pressure"
-        self._attr_name = "Turn-On Pressure"
+        self._attr_translation_key = "turn_on_pressure"
 
     @property
     def native_value(self) -> float | None:
@@ -217,7 +218,7 @@ class GardenaPumpDrippingAlert(GardenaEntity, NumberEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_dripping_alert"
-        self._attr_name = "Dripping Alert Timeout"
+        self._attr_translation_key = "dripping_alert_timeout"
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/gardena_smart_local_preview/select.py
+++ b/custom_components/gardena_smart_local_preview/select.py
@@ -70,7 +70,7 @@ class GardenaPumpOperatingModeSelect(GardenaEntity, SelectEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_operating_mode"
-        self._attr_name = "Operating Mode"
+        self._attr_translation_key = "operating_mode"
 
     @property
     def current_option(self) -> str | None:

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -152,7 +152,7 @@ class GardenaTemperatureSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_temperature"
-        self._attr_name = "Temperature"
+        self._attr_translation_key = "temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
@@ -174,7 +174,7 @@ class GardenaSoilMoistureSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_soil_moisture"
-        self._attr_name = "Soil Moisture"
+        self._attr_translation_key = "soil_moisture"
         self._attr_device_class = SensorDeviceClass.MOISTURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
@@ -196,7 +196,7 @@ class GardenaLightSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_light"
-        self._attr_name = "Light"
+        self._attr_translation_key = "light"
         self._attr_device_class = SensorDeviceClass.ILLUMINANCE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = LIGHT_LUX
@@ -218,7 +218,7 @@ class GardenaBatterySensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_battery"
-        self._attr_name = "Battery"
+        self._attr_translation_key = "battery"
         self._attr_device_class = SensorDeviceClass.BATTERY
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
@@ -240,7 +240,7 @@ class GardenaRfLinkQualitySensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_rf_link_quality"
-        self._attr_name = "RF Link Quality"
+        self._attr_translation_key = "rf_link_quality"
         self._attr_icon = "mdi:signal"
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = PERCENTAGE
@@ -262,7 +262,7 @@ class GardenaPumpPressureSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_outlet_pressure"
-        self._attr_name = "Outlet Pressure"
+        self._attr_translation_key = "outlet_pressure"
         self._attr_device_class = SensorDeviceClass.PRESSURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfPressure.BAR
@@ -283,7 +283,7 @@ class GardenaPumpTemperatureSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_outlet_temperature"
-        self._attr_name = "Outlet Temperature"
+        self._attr_translation_key = "outlet_temperature"
         self._attr_device_class = SensorDeviceClass.TEMPERATURE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfTemperature.CELSIUS
@@ -305,7 +305,7 @@ class GardenaPumpFlowRateSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_flow_rate"
-        self._attr_name = "Flow Rate"
+        self._attr_translation_key = "flow_rate"
         self._attr_device_class = SensorDeviceClass.VOLUME_FLOW_RATE
         self._attr_state_class = SensorStateClass.MEASUREMENT
         self._attr_native_unit_of_measurement = UnitOfVolumeFlowRate.LITERS_PER_HOUR
@@ -327,7 +327,7 @@ class GardenaPumpFlowTotalSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_flow_total"
-        self._attr_name = "Total Flow"
+        self._attr_translation_key = "total_flow"
         self._attr_device_class = SensorDeviceClass.WATER
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
@@ -349,7 +349,7 @@ class GardenaPumpFlowSinceResetSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_flow_since_reset"
-        self._attr_name = "Flow Since Reset"
+        self._attr_translation_key = "flow_since_reset"
         self._attr_device_class = SensorDeviceClass.WATER
         self._attr_state_class = SensorStateClass.TOTAL_INCREASING
         self._attr_native_unit_of_measurement = UnitOfVolume.CUBIC_METERS
@@ -371,7 +371,7 @@ class GardenaPumpStateSensor(GardenaEntity, SensorEntity):
     ) -> None:
         super().__init__(coordinator, device)
         self._attr_unique_id = f"{device.id}_pump_state"
-        self._attr_name = "Pump State"
+        self._attr_translation_key = "pump_state"
         self._attr_entity_category = EntityCategory.DIAGNOSTIC
 
     @property
@@ -386,8 +386,7 @@ class GardenaPumpStateSensor(GardenaEntity, SensorEntity):
 class GardenaScheduleCountSensor(GardenaEntity, SensorEntity):
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
-    _attr_has_entity_name = True
-    _attr_name = "Schedule Count"
+    _attr_translation_key = "schedule_count"
     _attr_icon = "mdi:calendar-check"
 
     def __init__(

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -1,6 +1,87 @@
 {
   "entity": {
+    "binary_sensor": {
+      "frost_warning": {
+        "name": "Frostwarnung"
+      }
+    },
+    "button": {
+      "identify": {
+        "name": "Identifizieren"
+      },
+      "reset_resettable_flow": {
+        "name": "Durchfluss zurücksetzen"
+      },
+      "reset_valve_errors": {
+        "name": "Ventilfehler zurücksetzen"
+      },
+      "reset_temperature_min_max": {
+        "name": "Temperatur-Min/Max zurücksetzen"
+      },
+      "clear_schedules": {
+        "name": "Zeitpläne löschen"
+      }
+    },
+    "number": {
+      "button_watering_duration": {
+        "name": "Bewässerungsdauer per Taste"
+      },
+      "button_watering_duration_numbered": {
+        "name": "Bewässerungsdauer der Taste {number}"
+      },
+      "turn_on_pressure": {
+        "name": "Einschaltdruck"
+      },
+      "dripping_alert_timeout": {
+        "name": "Tropfalarm-Zeitüberschreitung"
+      }
+    },
+    "select": {
+      "operating_mode": {
+        "name": "Betriebsmodus",
+        "state": {
+          "scheduled": "Geplant",
+          "automatic": "Automatisch"
+        }
+      }
+    },
     "sensor": {
+      "temperature": {
+        "name": "Temperatur"
+      },
+      "soil_moisture": {
+        "name": "Bodenfeuchtigkeit"
+      },
+      "light": {
+        "name": "Licht"
+      },
+      "battery": {
+        "name": "Batterie"
+      },
+      "rf_link_quality": {
+        "name": "Funkverbindungsqualität"
+      },
+      "outlet_pressure": {
+        "name": "Auslassdruck"
+      },
+      "outlet_temperature": {
+        "name": "Auslasstemperatur"
+      },
+      "flow_rate": {
+        "name": "Durchflussrate"
+      },
+      "total_flow": {
+        "name": "Gesamtdurchfluss"
+      },
+      "flow_since_reset": {
+        "name": "Durchfluss seit Rücksetzung"
+      },
+      "pump_state": {
+        "name": "Pumpenstatus"
+      },
+      "schedule_count": {
+        "name": "Anzahl Zeitpläne"
+      },
       "firmware_update_state": {
         "name": "Firmware-Update-Status",
         "state": {
@@ -9,6 +90,11 @@
           "downloaded": "Heruntergeladen",
           "updating": "Wird aktualisiert"
         }
+      }
+    },
+    "valve": {
+      "valve": {
+        "name": "Ventil {number}"
       }
     }
   },

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -1,6 +1,87 @@
 {
   "entity": {
+    "binary_sensor": {
+      "frost_warning": {
+        "name": "Frost warning"
+      }
+    },
+    "button": {
+      "identify": {
+        "name": "Identify"
+      },
+      "reset_resettable_flow": {
+        "name": "Reset flow"
+      },
+      "reset_valve_errors": {
+        "name": "Reset valve errors"
+      },
+      "reset_temperature_min_max": {
+        "name": "Reset temperature min/max"
+      },
+      "clear_schedules": {
+        "name": "Clear schedules"
+      }
+    },
+    "number": {
+      "button_watering_duration": {
+        "name": "Button watering duration"
+      },
+      "button_watering_duration_numbered": {
+        "name": "Button {number} watering duration"
+      },
+      "turn_on_pressure": {
+        "name": "Turn-on pressure"
+      },
+      "dripping_alert_timeout": {
+        "name": "Dripping alert timeout"
+      }
+    },
+    "select": {
+      "operating_mode": {
+        "name": "Operating mode",
+        "state": {
+          "scheduled": "Scheduled",
+          "automatic": "Automatic"
+        }
+      }
+    },
     "sensor": {
+      "temperature": {
+        "name": "Temperature"
+      },
+      "soil_moisture": {
+        "name": "Soil moisture"
+      },
+      "light": {
+        "name": "Light"
+      },
+      "battery": {
+        "name": "Battery"
+      },
+      "rf_link_quality": {
+        "name": "RF link quality"
+      },
+      "outlet_pressure": {
+        "name": "Outlet pressure"
+      },
+      "outlet_temperature": {
+        "name": "Outlet temperature"
+      },
+      "flow_rate": {
+        "name": "Flow rate"
+      },
+      "total_flow": {
+        "name": "Total flow"
+      },
+      "flow_since_reset": {
+        "name": "Flow since reset"
+      },
+      "pump_state": {
+        "name": "Pump state"
+      },
+      "schedule_count": {
+        "name": "Schedule count"
+      },
       "firmware_update_state": {
         "name": "Firmware Update State",
         "state": {
@@ -9,6 +90,11 @@
           "downloaded": "Downloaded",
           "updating": "Updating"
         }
+      }
+    },
+    "valve": {
+      "valve": {
+        "name": "Valve {number}"
       }
     }
   },

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -94,7 +94,11 @@ class GardenaValve(GardenaEntity, ValveEntity):
         self._entry = entry
         self._valve_id = valve_id
         self._attr_unique_id = f"{device.id}_valve_{valve_id}"
-        self._attr_name = f"Valve {valve_id + 1}" if len(device.valve_ids) > 1 else None
+        if len(device.valve_ids) > 1:
+            self._attr_translation_key = "valve"
+            self._attr_translation_placeholders = {"number": str(valve_id + 1)}
+        else:
+            self._attr_name = None
         self._attr_reports_position = False
         self._attr_supported_features = (
             ValveEntityFeature.OPEN | ValveEntityFeature.CLOSE


### PR DESCRIPTION
Entity names were hardcoded English strings via `_attr_name`. Adds `translation_key` (+ `strings.json`/`en.json`/`de.json` entries) across binary_sensor, button, number, select, sensor, and valve entities so names — and fixed select/number option labels — translate.

Primary device entities (single valve, switches, lawn mower) were left as-is; they intentionally have no separate name.

Progresses the `entity-translations` Gold quality-scale checklist item.