### PR TITLE
Expose pump state as a proper enum sensor

### DIFF
--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -9,6 +9,7 @@ from typing import ClassVar
 
 from gardena_smart_local_api.devices import Pump
 from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
+from gardena_smart_local_api.devices.irrigation import PumpState
 from homeassistant.components.sensor import (
     SensorDeviceClass,
     SensorEntity,
@@ -364,6 +365,9 @@ class GardenaPumpFlowSinceResetSensor(GardenaEntity, SensorEntity):
 
 
 class GardenaPumpStateSensor(GardenaEntity, SensorEntity):
+    _attr_device_class = SensorDeviceClass.ENUM
+    _attr_options: ClassVar = [str(state) for state in PumpState]
+
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -77,7 +77,14 @@
         "name": "Durchfluss seit Rücksetzung"
       },
       "pump_state": {
-        "name": "Pumpenstatus"
+        "name": "Pumpenstatus",
+        "state": {
+          "pump_is_just_starting": "Pumpe startet jetzt",
+          "water_in_the_pump_body": "Wasser in der Pumpe",
+          "no_water_in_the_pump_body": "Kein Wasser in der Pumpe",
+          "flow_after_5s": "Durchfluss nach 5 Sekunden",
+          "no_flow_after_5s": "Kein Durchfluss nach 5 Sekunden"
+        }
       },
       "schedule_count": {
         "name": "Anzahl Zeitpläne"

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -77,7 +77,14 @@
         "name": "Flow since reset"
       },
       "pump_state": {
-        "name": "Pump state"
+        "name": "Pump state",
+        "state": {
+          "pump_is_just_starting": "Pump is starting",
+          "water_in_the_pump_body": "Water in the pump",
+          "no_water_in_the_pump_body": "No water in the pump",
+          "flow_after_5s": "Flow after 5 seconds",
+          "no_flow_after_5s": "No flow after 5 seconds"
+        }
       },
       "schedule_count": {
         "name": "Schedule count"


### PR DESCRIPTION
`pump_state` returned a raw device string (e.g. `flow_after_5s`) untranslated, with no `device_class`. Its sibling `firmware_update_state` sensor already handles this correctly via `SensorDeviceClass.ENUM` + `_attr_options` + a `state` translation block — the library's `PumpState` enum is a fixed 5-value set, so wire `pump_state` up the same way.