### PR TITLE
Create device subentries synchronously on setup, not just on updates

### DIFF
--- a/custom_components/gardena_smart_local_preview/__init__.py
+++ b/custom_components/gardena_smart_local_preview/__init__.py
@@ -138,9 +138,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 )
                 _LOGGER.info("Migrated device %s to subentry", device.id)
 
-    # Register before platform listeners so subentries exist when
-    # platforms look them up for newly discovered devices.
+    # Register before platform listeners, and run once immediately, so
+    # subentries exist for already-discovered devices before platforms
+    # look them up during their own setup.
     entry.async_on_unload(coordinator.async_add_listener(_ensure_device_subentries))
+    _ensure_device_subentries()
 
     known_subentries: dict[str, str] = {
         sid: se.data["device_id"]


### PR DESCRIPTION
Devices could land as bare devices under the config entry instead of getting their own subentry, depending on load-order timing — reproduced on a fresh instance where one gateway's devices got subentries immediately and another gateway's didn't for several minutes (until some unrelated coordinator update happened to fire).

`_ensure_device_subentries` was registered as a coordinator listener but never called immediately, unlike every platform's `_add_new_devices`. Platform setup runs synchronously right after and looks up subentries that don't exist yet, so devices attach with `config_subentry_id=None` — and are never reconsidered once a platform's `known_devices` set marks them handled, since each platform only processes a device once.

Fix: call `_ensure_device_subentries()` once immediately after registering the listener, so subentries exist before platform setup looks them up.