### PR TITLE
Fix open-valve blueprint's Press button

### DIFF
--- a/blueprints/script/gardena_smart_local_preview/open_valve_with_duration.yaml
+++ b/blueprints/script/gardena_smart_local_preview/open_valve_with_duration.yaml
@@ -37,4 +37,9 @@ sequence:
     target:
       entity_id: !input valve
     data:
-      duration: "{{ duration | default(omit) }}"
+      # duration | default(omit) alone only catches a truly missing value.
+      # Calling the script without the fields form (e.g. the dashboard
+      # row's play icon) passes duration as None instead of omitting it,
+      # so the second `true` argument tells Jinja to also treat that
+      # falsy value as missing.
+      duration: "{{ duration | default(omit, true) }}"


### PR DESCRIPTION
Follow-up to #83's blueprint — [Reto's report on that PR](https://github.com/cloudless-garden/ha-gardena-smart-local-preview/pull/83) that the dashboard "Press" button does nothing.

Calling the script without the fields form (dashboard play icon / `script.turn_on` with no data) passes `duration` as `None` rather than omitting it, so `duration | default(omit)` never triggers — Jinja's `default()` only replaces truly `Undefined` values, not falsy ones. The service call then fails schema validation (`duration` must be ≥ 60), matching the error logged in #83's thread. Fixed with `default(omit, true)`.