### PR TITLE
Add documentation category to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -13,6 +13,9 @@ changelog:
     - title: ✨ Enhancements
       labels:
         - enhancement
+    - title: 📚 Documentation
+      labels:
+        - documentation
     - title: Other Changes
       labels:
         - "*"


### PR DESCRIPTION
PRs labeled `documentation` (like #94) landed in the flat "Other Changes" bucket alongside everything else, same gap #89 fixed for breaking-change/bug/enhancement.