### PR TITLE
Bump version to 0.2.0

### DIFF
--- a/custom_components/gardena_smart_local_preview/manifest.json
+++ b/custom_components/gardena_smart_local_preview/manifest.json
@@ -7,6 +7,6 @@
   "iot_class": "local_push",
   "issue_tracker": "https://github.com/cloudless-garden/ha-gardena-smart-local-preview/issues",
   "requirements": ["gardena-smart-local-api==0.1.2"],
-  "version": "0.1.0",
+  "version": "0.2.0",
   "zeroconf": ["_gardena-smart._tcp.local."]
 }


### PR DESCRIPTION
Minor bump (not patch) since #79 is a breaking change included since v0.1.0.

Changes since v0.1.0, grouped as the release notes will show them:

**⚠️ Breaking Changes**
- Model pump dripping alert as a select, not a number (#79)

**✨ Enhancements**
- Model pump dripping alert as a select, not a number (#79)
- Add per-valve duration config and one-off override service (#83)

**🐛 Bug Fixes**
- Await gateway reply for all commands, defer UI update until confirmed (#87)
- Update gardena-smart-local-api to version 0.1.2 (#88)
  - Add identify support for Gen2 devices (gardena-smart-local-api#81)
  - Add schedule parser/encoder utils (gardena-smart-local-api#73)
  - Fix Gen1 is_valve_open to detect scheduled watering (gardena-smart-local-api#84)
- Expose pump state as a proper enum sensor (#91)
- Create device subentries synchronously on setup, not just on updates (#92)
- Fix open-valve blueprint's Press button (#93)

**📚 Documentation**
- Document a valve-state card for the open-valve blueprint (#94)
- Add documentation category to release notes (#95)
- List Enhancements before Bug Fixes in release notes (#96)

**Other Changes**
- Add translation_key to entities, translate names into German (#90)
- Add release-notes categories for breaking changes, bugs, and enhancements (#89)