### PR TITLE
Warn about factory reset when updating Gen1 device firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,9 @@ If installed via HACS, you can also remove the integration files there: open HAC
 > [!NOTE]
 > The temperature sensor integrated into Water Control devices is intended solely for frost detection, not for precise real-time temperature tracking.
 
+> [!WARNING]
+> Installing a firmware update on a Gen1 device factory-resets its settings. Schedules and other configuration will be lost and need to be set up again afterwards. This does not affect Gen2 devices. The official GARDENA app writes the settings back to the device automatically after installing the update there, this integration does not, installing the update via the app avoids the loss.
+
 See [gardena-smart-local-api] for more details about the device types.
 
 [gardena-smart-local-api]: https://github.com/cloudless-garden/gardena-smart-local-api

--- a/custom_components/gardena_smart_local_preview/update.py
+++ b/custom_components/gardena_smart_local_preview/update.py
@@ -8,6 +8,7 @@ import logging
 from typing import Any
 
 from gardena_smart_local_api.devices.device import Device, FirmwareUpdateState
+from gardena_smart_local_api.devices.gen1 import Gen1Device
 from homeassistant.components.update import (
     UpdateDeviceClass,
     UpdateEntity,
@@ -77,6 +78,19 @@ class GardenaFirmwareUpdate(GardenaEntity, UpdateEntity):
     def installed_version(self) -> str | None:
         device = self.coordinator.data.get(self._device.id)
         return device.software_version if device else None
+
+    @property
+    def release_summary(self) -> str | None:
+        if isinstance(self._device, Gen1Device):
+            return (
+                "This Gen1 device factory-resets its settings during the "
+                "update. Schedules and other configuration will be lost and "
+                "need to be set up again afterwards. The official GARDENA "
+                "app writes the settings back to the device automatically "
+                "after installing the update there, this integration does "
+                "not."
+            )
+        return None
 
     @property
     def latest_version(self) -> str | None:


### PR DESCRIPTION
Gen1 devices factory-reset their settings during a firmware update, losing
schedules and other configuration. The official GARDENA app rewrites the
settings back to the device automatically after installing an update there,
this integration does not.

Shown in the update entity's release summary (visible in the more-info
dialog before install) and noted in the README. HA's update entity has no
confirm-before-install hook, so this can only warn, not block the action.