### PR TITLE
Add enable_output service with configurable duration for power outlets

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,38 @@ Duration field as a form and runs the script on confirm — no custom
 open/close service calls needed. The `valve-open-close` feature adds real
 Open/Close buttons for the valve entity directly on the card face.
 
+### Power On (with duration)
+
+Same idea as the valve blueprint, for the `enable_output` action: it wraps the
+service in a script so its more-info dialog renders the `duration` field as
+a form, letting you pick a one-off on-time from the dashboard.
+
+[![Open your Home Assistant instance and show the blueprint import dialog with a specific blueprint pre-filled.](https://my.home-assistant.io/badges/blueprint_import.svg)](https://my.home-assistant.io/redirect/blueprint_import/?blueprint_url=https%3A%2F%2Fraw.githubusercontent.com%2Fcloudless-garden%2Fha-gardena-smart-local-preview%2Fmain%2Fblueprints%2Fscript%2Fgardena_smart_local_preview%2Fenable_output_with_duration.yaml)
+
+After importing, create a script from the blueprint and pick the power
+outlet.
+
+The same caveat as the valve applies: the script's own state always reads
+"off" the instant the command is acknowledged, not while the outlet is
+actually on. Point a tile card at the **outlet's switch entity** instead
+(it tracks the real on/off state, same as the valve entity), with `tap_action`
+set to open the script's more-info dialog for the duration form. Unlike the
+valve, no extra tile feature is used here: a plain tile pointed at the
+switch entity already lets you tap the icon to toggle it directly via
+`icon_tap_action`. The valve section's `valve-open-close` feature above is
+just an optional convenience for visible Open/Close buttons; switches don't
+need an equivalent since on/off is already the whole story:
+
+```yaml
+type: tile
+entity: switch.gardena_smart_power_adapter_xxxxxxxx # change to your power outlet
+tap_action:
+  action: more-info
+  entity: script.enable_output_of_gardena_smart_power_adapter_with_duration # change if necessary
+icon_tap_action:
+  action: toggle
+```
+
 ## Removal
 
 1. Go to **Settings → Devices & Services**

--- a/blueprints/script/gardena_smart_local_preview/enable_output_with_duration.yaml
+++ b/blueprints/script/gardena_smart_local_preview/enable_output_with_duration.yaml
@@ -1,0 +1,45 @@
+# SPDX-FileCopyrightText: 2026 GARDENA GmbH
+#
+# SPDX-License-Identifier: Apache-2.0
+
+blueprint:
+  name: Enable output of GARDENA smart Power Adapter (with duration)
+  description: >-
+    Enables the output of a GARDENA smart Power Adapter, optionally overriding its
+    configured duration for this run only.
+  domain: script
+  source_url: https://github.com/cloudless-garden/ha-gardena-smart-local-preview/blob/main/blueprints/script/gardena_smart_local_preview/enable_output_with_duration.yaml
+  input:
+    socket:
+      name: Power outlet
+      description: The power outlet to turn on.
+      selector:
+        entity:
+          filter:
+            integration: gardena_smart_local_preview
+            domain: switch
+            device_class: outlet
+
+fields:
+  duration:
+    name: Duration
+    description: How long to keep the output enabled.
+    required: false
+    selector:
+      duration:
+        enable_day: false
+
+sequence:
+  - action: gardena_smart_local_preview.enable_output
+    target:
+      entity_id: !input socket
+    data:
+      # Calling the script without the fields form (e.g. the dashboard row's
+      # play icon) passes duration as None instead of omitting it, so
+      # default(none, true) normalizes both cases to None first. The
+      # duration selector gives back an {hours, minutes, seconds} dict;
+      # the enable_output service itself wants a plain number of seconds.
+      duration: >-
+        {% set d = duration | default(none, true) %}{{ omit if d is none else
+        ((d.hours | default(0) | int) * 3600 + (d.minutes | default(0) | int) * 60 +
+        (d.seconds | default(0) | int)) }}

--- a/custom_components/gardena_smart_local_preview/const.py
+++ b/custom_components/gardena_smart_local_preview/const.py
@@ -6,6 +6,9 @@ DOMAIN = "gardena_smart_local_preview"
 
 DEFAULT_PORT = 8443
 DEFAULT_VALVE_DURATION_MINUTES = 30
+DEFAULT_POWER_DURATION_MINUTES = 30
 
 # Subentry data key holding {str(valve_id): minutes} for a device's valves
 CONF_VALVE_DURATIONS = "valve_durations"
+# Subentry data key holding a power outlet's default timed-on duration, in minutes
+CONF_POWER_DURATION = "power_duration"

--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -12,7 +12,13 @@ from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_VALVE_DURATIONS, DEFAULT_VALVE_DURATION_MINUTES, DOMAIN
+from .const import (
+    CONF_POWER_DURATION,
+    CONF_VALVE_DURATIONS,
+    DEFAULT_POWER_DURATION_MINUTES,
+    DEFAULT_VALVE_DURATION_MINUTES,
+    DOMAIN,
+)
 from .coordinator import COMMAND_REPLY_TIMEOUT, GardenaSmartLocalCoordinator
 
 
@@ -59,6 +65,34 @@ def async_set_valve_duration_minutes(
     durations[str(valve_id)] = minutes
     hass.config_entries.async_update_subentry(
         entry, subentry, data={**subentry.data, CONF_VALVE_DURATIONS: durations}
+    )
+
+
+def get_power_duration_minutes(entry: ConfigEntry, device_id: str) -> int:
+    # Falls back to the default for devices without a subentry, and for
+    # outlets the user has never configured.
+    subentry_id = find_device_subentry_id(entry, device_id)
+    if subentry_id is None:
+        return DEFAULT_POWER_DURATION_MINUTES
+    minutes = entry.subentries[subentry_id].data.get(CONF_POWER_DURATION)
+    if not isinstance(minutes, int):
+        return DEFAULT_POWER_DURATION_MINUTES
+    return minutes
+
+
+@callback
+def async_set_power_duration_minutes(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    device_id: str,
+    minutes: int,
+) -> None:
+    subentry_id = find_device_subentry_id(entry, device_id)
+    if subentry_id is None:
+        return
+    subentry = entry.subentries[subentry_id]
+    hass.config_entries.async_update_subentry(
+        entry, subentry, data={**subentry.data, CONF_POWER_DURATION: minutes}
     )
 
 

--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 
-from gardena_smart_local_api.devices import Pump
+from gardena_smart_local_api.devices import PowerAdapter, Pump
 from gardena_smart_local_api.devices.device import Device
 from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
@@ -18,8 +18,10 @@ from .const import DEFAULT_VALVE_DURATION_MINUTES
 from .coordinator import GardenaSmartLocalCoordinator
 from .entity import (
     GardenaEntity,
+    async_set_power_duration_minutes,
     async_set_valve_duration_minutes,
     find_device_subentry_id,
+    get_power_duration_minutes,
     get_valve_duration_minutes,
 )
 
@@ -81,6 +83,15 @@ async def async_setup_entry(
                     GardenaPumpTurnOnPressure(coordinator, device)
                 )
                 _LOGGER.info("Adding new pump number entity for device %s", device.id)
+            elif isinstance(device, PowerAdapter) and device.id not in known_devices:
+                known_devices.add(device.id)
+                sid = find_device_subentry_id(entry, device.id)
+                entities_by_subentry_id.setdefault(sid, []).append(
+                    GardenaPowerDuration(coordinator, entry, device)
+                )
+                _LOGGER.info(
+                    "Adding new power outlet duration entity for device %s", device.id
+                )
 
             new_valve_ids: list[int] = []
             for valve_id in getattr(device, "valve_ids", []):
@@ -247,5 +258,48 @@ class GardenaValveDuration(GardenaEntity, NumberEntity):
             "Set valve duration for device %s valve_id=%s to %s minutes",
             self._device.id,
             self._valve_id,
+            minutes,
+        )
+
+
+class GardenaPowerDuration(GardenaEntity, NumberEntity):
+    _attr_native_min_value = 1
+    _attr_native_max_value = 180
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = UnitOfTime.MINUTES
+    _attr_mode = NumberMode.BOX
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: GardenaSmartLocalCoordinator,
+        entry: ConfigEntry,
+        device: PowerAdapter,
+    ) -> None:
+        super().__init__(coordinator, device)
+        self._entry = entry
+        self._attr_unique_id = f"{device.id}_power_duration"
+        self._attr_name = "Default On Duration"
+        self._attr_icon = "mdi:timer-outline"
+
+    # Stored in the config subentry rather than read from the device, so it
+    # stays settable while the gateway or the device itself is unreachable.
+    @property
+    def available(self) -> bool:
+        return True
+
+    @property
+    def native_value(self) -> float | None:
+        return get_power_duration_minutes(self._entry, self._device.id)
+
+    async def async_set_native_value(self, value: float) -> None:
+        minutes = int(value)
+        async_set_power_duration_minutes(
+            self.hass, self._entry, self._device.id, minutes
+        )
+        self.async_write_ha_state()
+        _LOGGER.info(
+            "Set power outlet duration for device %s to %s minutes",
+            self._device.id,
             minutes,
         )

--- a/custom_components/gardena_smart_local_preview/services.yaml
+++ b/custom_components/gardena_smart_local_preview/services.yaml
@@ -17,3 +17,18 @@ open_valve:
           max: 10800
           unit_of_measurement: s
           mode: box
+
+enable_output:
+  target:
+    entity:
+      integration: gardena_smart_local_preview
+      domain: switch
+  fields:
+    duration:
+      required: false
+      example: 900
+      selector:
+        number:
+          min: 1
+          unit_of_measurement: s
+          mode: box

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -7,14 +7,16 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import voluptuous as vol
 from gardena_smart_local_api.devices import PowerAdapter, Pump
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_platform
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
-from .entity import GardenaEntity, find_device_subentry_id
+from .entity import GardenaEntity, find_device_subentry_id, get_power_duration_minutes
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -34,6 +36,18 @@ async def async_setup_entry(
     coordinator: GardenaSmartLocalCoordinator = entry.runtime_data
     known_devices: set[str] = set()
 
+    platform = entity_platform.async_get_current_platform()
+    platform.async_register_entity_service(
+        "enable_output",
+        {
+            # min=1 only to avoid colliding with 0, which build_enable_output_obj
+            # treats as "disable" rather than "on for 0 seconds". Unlike the
+            # valve/pump, the outlet has no app-defined upper duration limit.
+            vol.Optional("duration"): vol.All(vol.Coerce(int), vol.Range(min=1))
+        },
+        "async_turn_on_for",
+    )
+
     def _add_new_devices() -> None:
         if not coordinator.data:
             return
@@ -44,7 +58,7 @@ async def async_setup_entry(
                 known_devices.add(device.id)
                 sid = find_device_subentry_id(entry, device.id)
                 entities_by_subentry_id.setdefault(sid, []).append(
-                    GardenaPowerSwitch(coordinator, device)
+                    GardenaPowerSwitch(coordinator, entry, device)
                 )
                 _LOGGER.info("Adding new switch entity for device %s", device.id)
             elif isinstance(device, Pump) and device.id not in known_devices:
@@ -65,9 +79,11 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
     def __init__(
         self,
         coordinator: GardenaSmartLocalCoordinator,
+        entry: ConfigEntry,
         device: PowerAdapter,
     ) -> None:
         super().__init__(coordinator, device)
+        self._entry = entry
         self._attr_unique_id = f"{device.id}_switch"
         self._attr_name = None
         self._attr_device_class = SwitchDeviceClass.OUTLET
@@ -84,6 +100,17 @@ class GardenaPowerSwitch(GardenaEntity, SwitchEntity):
             self._device.build_enable_output_obj(DEFAULT_ON_DURATION_SECONDS)
         )
         _LOGGER.info("Turning on switch %s", self._device.id)
+
+    async def async_turn_on_for(self, duration: int | None = None) -> None:
+        if duration is None:
+            minutes = get_power_duration_minutes(self._entry, self._device.id)
+            duration = minutes * 60
+        await self._send_confirmed_command(
+            self._device.build_enable_output_obj(duration)
+        )
+        _LOGGER.info(
+            "Turning on switch %s duration=%s seconds", self._device.id, duration
+        )
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self._send_confirmed_command(self._device.build_disable_output_obj())

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -146,6 +146,16 @@
           "description": "Wie lange das Ventil geöffnet bleibt, in Sekunden (60-10800). Ohne Angabe wird die konfigurierte Dauer des Ventils verwendet."
         }
       }
+    },
+    "enable_output": {
+      "name": "Ausgang aktivieren",
+      "description": "Schaltet eine Steckdose für eine feste Dauer ein, optional mit einer abweichenden Dauer nur für diesen Aufruf. Das Gerät schaltet sich automatisch aus, sobald diese Dauer abgelaufen ist.",
+      "fields": {
+        "duration": {
+          "name": "Dauer",
+          "description": "Wie lange die Steckdose eingeschaltet bleibt, in Sekunden (mindestens 1). Ohne Angabe wird die konfigurierte Dauer der Steckdose verwendet."
+        }
+      }
     }
   },
   "config": {

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -146,6 +146,16 @@
           "description": "How long to keep the valve open, in seconds (60-10800). Defaults to the valve's configured duration if omitted."
         }
       }
+    },
+    "enable_output": {
+      "name": "Enable output",
+      "description": "Enables the output of a power outlet for a fixed duration, optionally overriding its configured duration for this call only. The output is disabled automatically once that duration has elapsed.",
+      "fields": {
+        "duration": {
+          "name": "Duration",
+          "description": "How long to keep the outlet on, in seconds (minimum 1). Defaults to the outlet's configured duration if omitted."
+        }
+      }
     }
   },
   "config": {


### PR DESCRIPTION
Mirrors `open_valve`: a plain switch `turn_on` stays indefinite as before, `enable_output` lets automations/dashboards run the outlet for a fixed duration instead, with auto-off.

`build_enable_output_obj` already supports a timed duration (`power_timer`).

Includes a script blueprint (`enable_output_with_duration.yaml`) mirroring the existing open-valve one.