### PR TITLE
Reject pump switch toggle while in automatic mode

### DIFF
--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -8,9 +8,11 @@ import logging
 from typing import Any
 
 from gardena_smart_local_api.devices import PowerAdapter, Pump
+from gardena_smart_local_api.devices.irrigation import PumpOperatingMode
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ServiceValidationError
 from homeassistant.helpers.entity_platform import AddConfigEntryEntitiesCallback
 
 from .coordinator import GardenaSmartLocalCoordinator
@@ -107,12 +109,32 @@ class GardenaPumpSwitch(GardenaEntity, SwitchEntity):
             return None
         return device.is_running
 
+    def _raise_if_automatic(self) -> None:
+        # In automatic mode the device ignores manual start/stop writes and
+        # keeps deciding for itself based on outlet pressure (runs when
+        # below turn_on_pressure), so the switch would silently revert.
+        # Reject client-side instead of sending a command that's going to
+        # be dropped.
+        #
+        # The frontend still optimistically flips the toggle on tap and
+        # snaps back once this error lands (standard HA switch-tile
+        # behavior for any rejected service call) - a harmless visual
+        # flicker, not a bug. available=False would avoid the flicker but
+        # also hide the switch's real on/off state, which is worse.
+        if self._device.operating_mode == PumpOperatingMode.AUTOMATIC:
+            raise ServiceValidationError(
+                f"{self.entity_id} is in automatic mode, switch it to "
+                "scheduled mode first"
+            )
+
     async def async_turn_on(self, **kwargs: Any) -> None:
+        self._raise_if_automatic()
         await self._send_confirmed_command(
             self._device.build_start_obj(DEFAULT_ON_DURATION_SECONDS)
         )
         _LOGGER.info("Turning on pump %s", self._device.id)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
+        self._raise_if_automatic()
         await self._send_confirmed_command(self._device.build_stop_obj())
         _LOGGER.info("Turning off pump %s", self._device.id)


### PR DESCRIPTION
Toggling the pump's switch entity while it's in automatic mode currently
sends a command the device ignores (it keeps deciding for itself based on
outlet pressure, running when below `turn_on_pressure`), so the switch
just snaps back to its actual state. Working as intended on the device
side, but reads as a bug in the UI.

Guards `async_turn_on`/`async_turn_off` on `GardenaPumpSwitch`: if
`device.operating_mode == PumpOperatingMode.AUTOMATIC`, raise
`ServiceValidationError` before sending anything, instead of a
silent round-trip.

Deliberately not using `available = False` here — that's meant for
"can't reach the device," not "action rejected in this mode," and
would hide the real on/off state the switch should keep showing.

**Known cosmetic quirk:** manually tested — the toggle still visually
flips on tap and snaps back once the error lands. That's standard HA
switch-tile behavior for any rejected service call, not something this
fix controls, and not worth trading for `available = False`.

See cloudless-garden/gardena-smart-local-api#90 for the same guard
moved down into the lib itself (`Pump.build_start_obj`), so any
consumer gets it, not just this integration.