### PR TITLE
Fix websocket connect timeout not being applied

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -180,7 +180,8 @@ async def _async_try_connect(host: str, port: int, password: str) -> str | None:
                 URL.build(scheme="wss", host=host, port=port),
                 ssl=ssl_context,
                 headers={"Authorization": f"Basic {auth_b64}"},
-                timeout=aiohttp.ClientTimeout(total=10),
+                # ty doesn't resolve aiohttp's legacy attr.ib()-based __init__.
+                timeout=aiohttp.ClientWSTimeout(ws_receive=10),  # ty: ignore[unknown-argument]
             ) as ws,
         ):
             await ws.close()


### PR DESCRIPTION
aiohttp.ws_connect() expects a ClientWSTimeout for its timeout argument; passing ClientTimeout silently fell through to a deprecated code path that discarded the intended 10s connect bound.