### PR TITLE
Use HA's shared aiohttp session instead of creating own

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -15,7 +15,8 @@ from homeassistant.config_entries import (
     SubentryFlowResult,
 )
 from homeassistant.const import CONF_HOST, CONF_PASSWORD, CONF_PORT
-from homeassistant.core import callback
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.service_info.zeroconf import ZeroconfServiceInfo
 from homeassistant.helpers.typing import ConfigType
 from homeassistant.util.ssl import get_default_no_verify_context
@@ -52,6 +53,7 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
 
             error = await _async_try_connect(
+                self.hass,
                 user_input[CONF_HOST],
                 user_input[CONF_PORT],
                 user_input[CONF_PASSWORD],
@@ -102,6 +104,7 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             error = await _async_try_connect(
+                self.hass,
                 user_input[CONF_HOST],
                 user_input[CONF_PORT],
                 user_input.get(CONF_PASSWORD, ""),
@@ -137,6 +140,7 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             error = await _async_try_connect(
+                self.hass,
                 user_input[CONF_HOST],
                 user_input[CONF_PORT],
                 user_input.get(CONF_PASSWORD, ""),
@@ -168,21 +172,22 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         return self.async_create_entry(title="GARDENA smart local", data=import_data)
 
 
-async def _async_try_connect(host: str, port: int, password: str) -> str | None:
+async def _async_try_connect(
+    hass: HomeAssistant, host: str, port: int, password: str
+) -> str | None:
     ssl_context = get_default_no_verify_context()
 
     auth_b64 = base64.b64encode(f"_:{password}".encode()).decode("ascii")
 
     try:
-        async with (
-            aiohttp.ClientSession() as session,
-            session.ws_connect(
-                URL.build(scheme="wss", host=host, port=port),
-                ssl=ssl_context,
-                headers={"Authorization": f"Basic {auth_b64}"},
-                timeout=aiohttp.ClientTimeout(total=10),
-            ) as ws,
-        ):
+        session = async_get_clientsession(hass)
+        async with session.ws_connect(
+            URL.build(scheme="wss", host=host, port=port),
+            ssl=ssl_context,
+            headers={"Authorization": f"Basic {auth_b64}"},
+            # ty doesn't resolve aiohttp's legacy attr.ib()-based __init__.
+            timeout=aiohttp.ClientWSTimeout(ws_receive=10),  # ty: ignore[unknown-argument]
+        ) as ws:
             await ws.close()
     except aiohttp.WSServerHandshakeError as err:
         if err.status == 401:

--- a/custom_components/gardena_smart_local_preview/coordinator.py
+++ b/custom_components/gardena_smart_local_preview/coordinator.py
@@ -25,6 +25,7 @@ from gardena_smart_local_api.sgtin96 import SGTIN96Info
 from gardena_smart_local_api.utils import deep_merge_dict
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 from homeassistant.util.ssl import get_default_no_verify_context
 from yarl import URL
@@ -132,15 +133,13 @@ class GardenaSmartLocalCoordinator(DataUpdateCoordinator[DeviceMap]):
             consumer_task = None
             try:
                 _LOGGER.debug("Connecting to GARDENA smart Gateway at %s", self.uri)
-                async with (
-                    aiohttp.ClientSession() as session,
-                    session.ws_connect(
-                        self.uri,
-                        ssl=self._ssl_context,
-                        heartbeat=30,
-                        headers={"Authorization": f"Basic {self.auth_b64}"},
-                    ) as ws,
-                ):
+                session = async_get_clientsession(self.hass)
+                async with session.ws_connect(
+                    self.uri,
+                    ssl=self._ssl_context,
+                    heartbeat=30,
+                    headers={"Authorization": f"Basic {self.auth_b64}"},
+                ) as ws:
                     self._ws = ws
                     _LOGGER.info("Connected to GARDENA smart Gateway at %s", self.uri)
 


### PR DESCRIPTION
Reuses Home Assistant's managed aiohttp session instead of opening a fresh ClientSession per connection attempt (required for platinum quality scale's inject-websession).