### PR TITLE
Fix flow rate sensor reporting 100 L/h when pump is off

### DIFF
--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -316,6 +316,11 @@ class GardenaPumpFlowRateSensor(GardenaEntity, SensorEntity):
         device = self.coordinator.data.get(self._device.id)
         if not device:
             return None
+        # The gateway reports flow_rate=100 as a default/calibration value
+        # even when the pump is stopped. Only report a real flow when the
+        # pump is actually running.
+        if not device.is_running:
+            return 0.0
         rate = device.flow_rate
         return float(rate) if rate is not None else None
 


### PR DESCRIPTION
Add fix: report 0 L/h flow rate when pump is not running (instead of 100)
Check for device running state before reporting flow rate.

Closes #112 