### PR TITLE
Trim and validate the host in the config flow

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -27,6 +27,10 @@ from .coordinator import GardenaSmartLocalCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+# A host pasted with surrounding whitespace is rejected by yarl; trim it in
+# one place so every step stores and connects to the clean value.
+_HOST = vol.All(str, str.strip)
+
 
 class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
     VERSION = 1
@@ -70,7 +74,7 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST): str,
+                    vol.Required(CONF_HOST): _HOST,
                     vol.Optional(CONF_PORT, default=DEFAULT_PORT): int,
                     vol.Optional(CONF_PASSWORD, default=""): str,
                 }
@@ -121,7 +125,7 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="discovery_confirm",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default=self._discovered_host): str,
+                    vol.Required(CONF_HOST, default=self._discovered_host): _HOST,
                     vol.Optional(CONF_PORT, default=self._discovered_port): int,
                     vol.Optional(CONF_PASSWORD, default=""): str,
                 }
@@ -154,7 +158,9 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="reconfigure",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_HOST, default=entry.data.get(CONF_HOST, "")): str,
+                    vol.Required(
+                        CONF_HOST, default=entry.data.get(CONF_HOST, "")
+                    ): _HOST,
                     vol.Optional(
                         CONF_PORT, default=entry.data.get(CONF_PORT, DEFAULT_PORT)
                     ): int,
@@ -167,6 +173,7 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         )
 
     async def async_step_import(self, import_data: ConfigType) -> ConfigFlowResult:
+        import_data[CONF_HOST] = _HOST(import_data[CONF_HOST])
         await self.async_set_unique_id(import_data[CONF_HOST])
         self._abort_if_unique_id_configured()
         return self.async_create_entry(title="GARDENA smart local", data=import_data)
@@ -197,6 +204,10 @@ async def _async_try_connect(
     except (aiohttp.ClientConnectionError, TimeoutError, OSError):
         _LOGGER.debug("Error connecting to %s:%s", host, port, exc_info=True)
         return "cannot_connect"
+    except ValueError:
+        # yarl rejects a host that is empty or contains spaces/control chars.
+        _LOGGER.debug("Invalid host %r", host)
+        return "invalid_host"
     except Exception:
         _LOGGER.exception("Unexpected error connecting to %s:%s", host, port)
         return "unknown"

--- a/custom_components/gardena_smart_local_preview/translations/de.json
+++ b/custom_components/gardena_smart_local_preview/translations/de.json
@@ -201,6 +201,7 @@
     "error": {
       "cannot_connect": "Verbindung zum Gateway fehlgeschlagen",
       "invalid_auth": "Falsches Passwort",
+      "invalid_host": "Ungültiger Hostname oder ungültige IP-Adresse",
       "unknown": "Unerwarteter Fehler"
     },
     "abort": {

--- a/custom_components/gardena_smart_local_preview/translations/en.json
+++ b/custom_components/gardena_smart_local_preview/translations/en.json
@@ -201,6 +201,7 @@
     "error": {
       "cannot_connect": "Failed to connect to the gateway",
       "invalid_auth": "Invalid password",
+      "invalid_host": "Invalid hostname or IP address",
       "unknown": "Unexpected error"
     },
     "abort": {

--- a/custom_components/gardena_smart_local_preview/translations/fr.json
+++ b/custom_components/gardena_smart_local_preview/translations/fr.json
@@ -191,6 +191,7 @@
     "error": {
       "cannot_connect": "Échec de connexion à la passerelle",
       "invalid_auth": "Mot de passe invalide",
+      "invalid_host": "Nom d'hôte ou adresse IP invalide",
       "unknown": "Erreur inattendue"
     },
     "abort": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -83,6 +83,29 @@ async def test_user_flow_success(hass: HomeAssistant, mock_setup_entry) -> None:
     }
 
 
+async def test_user_flow_strips_host_whitespace(
+    hass: HomeAssistant, mock_setup_entry
+) -> None:
+    """Leading/trailing whitespace in the host is stripped before use."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    with patch(PATCH_TRY_CONNECT, return_value=None) as try_connect:
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                CONF_HOST: f"  {MOCK_HOST}\t",
+                CONF_PORT: MOCK_PORT,
+                CONF_PASSWORD: MOCK_PASSWORD,
+            },
+        )
+
+    assert result["type"] == "create_entry"
+    assert result["data"][CONF_HOST] == MOCK_HOST
+    assert try_connect.call_args[0][1] == MOCK_HOST
+
+
 async def test_user_flow_cannot_connect(hass: HomeAssistant) -> None:
     """Connection failure shows an error and keeps the form open."""
     result = await hass.config_entries.flow.async_init(
@@ -143,6 +166,25 @@ async def test_user_flow_unknown_error(hass: HomeAssistant) -> None:
 
     assert result["type"] == "form"
     assert result["errors"] == {"base": "unknown"}
+
+
+async def test_user_flow_invalid_host(hass: HomeAssistant) -> None:
+    """A malformed host is reported as invalid, not as an unknown error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": SOURCE_USER}
+    )
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            CONF_HOST: "10.0.1.194 junk",
+            CONF_PORT: MOCK_PORT,
+            CONF_PASSWORD: MOCK_PASSWORD,
+        },
+    )
+
+    assert result["type"] == "form"
+    assert result["errors"] == {"base": "invalid_host"}
 
 
 async def test_user_flow_already_configured(hass: HomeAssistant) -> None:


### PR DESCRIPTION
Two small config-flow fixes for bad host input, both seen while testing against a local gateway:

- **Whitespace** — a host pasted with a leading or trailing space failed with a bare `unknown` error (yarl rejects a host containing whitespace) and the host field was cleared. The host is now trimmed in every step that accepts one, so a padded value behaves like the clean one: it connects, or aborts as `already_configured`.
- **Malformed host** — a host with an inner space or other characters yarl rejects raised a `ValueError` that fell through to the catch-all, logging a full traceback at ERROR level and showing `unknown`. It now returns a dedicated `invalid_host` error and logs at debug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
