### PR TITLE
Re-add entities after re-including a removed device

### DIFF
--- a/custom_components/gardena_smart_local_preview/number.py
+++ b/custom_components/gardena_smart_local_preview/number.py
@@ -43,22 +43,27 @@ async def async_setup_entry(
     known_valves: set[tuple[str, int]] = set()
 
     def _add_new_devices() -> None:
-        if not coordinator.data:
-            return
-        known_devices.intersection_update(coordinator.data)
+        # Prune the caches before the empty-data guard: when the last device
+        # subentry is removed coordinator.data is empty, and a stale key here
+        # would stop the same device's entities from being re-added if it is
+        # included again.
+        current = coordinator.data or {}
+        known_devices.intersection_update(current)
         known_button_time_valves.intersection_update(
             (device.id, valve_id)
-            for device in coordinator.data.values()
+            for device in current.values()
             if hasattr(device, "build_set_button_config_time_obj")
             for valve_id in device.valve_ids
         )
 
         current_valves: set[tuple[str, int]] = set()
-        for device in coordinator.data.values():
+        for device in current.values():
             for valve_id in getattr(device, "valve_ids", []):
                 current_valves.add((device.id, valve_id))
         known_valves.intersection_update(current_valves)
 
+        if not coordinator.data:
+            return
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if hasattr(device, "build_set_button_config_time_obj"):

--- a/custom_components/gardena_smart_local_preview/sensor.py
+++ b/custom_components/gardena_smart_local_preview/sensor.py
@@ -54,8 +54,10 @@ async def async_setup_entry(
     known_firmware_state_devices: set[str] = set()
 
     def _add_new_devices() -> None:
-        if not coordinator.data:
-            return
+        # Prune the caches before the empty-data guard: when the last device
+        # subentry is removed coordinator.data is empty, and a stale key here
+        # would stop the same device's entities from being re-added if it is
+        # included again.
         for cache in (
             known_temp_devices,
             known_moisture_devices,
@@ -66,7 +68,9 @@ async def async_setup_entry(
             known_schedule_devices,
             known_firmware_state_devices,
         ):
-            cache.intersection_update(coordinator.data)
+            cache.intersection_update(coordinator.data or {})
+        if not coordinator.data:
+            return
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             device_entities = []

--- a/custom_components/gardena_smart_local_preview/switch.py
+++ b/custom_components/gardena_smart_local_preview/switch.py
@@ -49,9 +49,13 @@ async def async_setup_entry(
     )
 
     def _add_new_devices() -> None:
+        # Prune the cache before the empty-data guard: when the last device
+        # subentry is removed coordinator.data is empty, and a stale key here
+        # would stop the same device's entities from being re-added if it is
+        # included again.
+        known_devices.intersection_update(coordinator.data or {})
         if not coordinator.data:
             return
-        known_devices.intersection_update(coordinator.data)
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if isinstance(device, PowerAdapter) and device.id not in known_devices:

--- a/custom_components/gardena_smart_local_preview/valve.py
+++ b/custom_components/gardena_smart_local_preview/valve.py
@@ -49,14 +49,18 @@ async def async_setup_entry(
     )
 
     def _add_new_devices() -> None:
-        if not coordinator.data:
-            return
+        # Prune the cache before the empty-data guard: when the last device
+        # subentry is removed coordinator.data is empty, and a stale key here
+        # would stop the same device's entities from being re-added if it is
+        # included again.
         known_valves.intersection_update(
             (device.id, valve_id)
-            for device in coordinator.data.values()
+            for device in (coordinator.data or {}).values()
             if hasattr(device, "valve_ids")
             for valve_id in device.valve_ids
         )
+        if not coordinator.data:
+            return
         entities_by_subentry_id: dict[str | None, list] = {}
         for device in coordinator.data.values():
             if not hasattr(device, "valve_ids"):


### PR DESCRIPTION
`_add_new_devices` returned early when `coordinator.data` was empty, *before* pruning the `known_*` cache. Removing the last device subentry empties `coordinator.data`, so the stale `(device_id, valve_id)` / `device_id` keys stayed. Re-including the same device then hit `key in known_*`, skipped `async_add_entities`, and the entities never returned until a Home Assistant restart.

Fix: prune the cache before the empty-data guard, in `valve.py`, `switch.py`, `number.py` and `sensor.py`.

Surfaced by the Copilot review on the core PR (home-assistant/core#176988); fixed there in the same way (valve platform only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
