### PR TITLE
Harden the config flow connection probe and reconfigure

### DIFF
--- a/custom_components/gardena_smart_local_preview/config_flow.py
+++ b/custom_components/gardena_smart_local_preview/config_flow.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import base64
 import logging
 
@@ -143,6 +144,10 @@ class GardenaSmartLocalConfigFlow(ConfigFlow, domain=DOMAIN):
         entry = self._get_reconfigure_entry()
 
         if user_input is not None:
+            if user_input[CONF_HOST] != entry.data.get(CONF_HOST):
+                # Only a changed host can collide, and only with a different
+                # entry: matching the current one would abort every save.
+                self._async_abort_entries_match({CONF_HOST: user_input[CONF_HOST]})
             error = await _async_try_connect(
                 self.hass,
                 user_input[CONF_HOST],
@@ -188,13 +193,17 @@ async def _async_try_connect(
 
     try:
         session = async_get_clientsession(hass)
-        async with session.ws_connect(
-            URL.build(scheme="wss", host=host, port=port),
-            ssl=ssl_context,
-            headers={"Authorization": f"Basic {auth_b64}"},
-            # ty doesn't resolve aiohttp's legacy attr.ib()-based __init__.
-            timeout=aiohttp.ClientWSTimeout(ws_receive=10),  # ty: ignore[unknown-argument]
-        ) as ws:
+        # ClientWSTimeout only bounds receive(); this probe never receives a
+        # frame, so an unreachable host would otherwise hang on aiohttp's
+        # much longer default. Cap the whole attempt.
+        async with (
+            asyncio.timeout(10),
+            session.ws_connect(
+                URL.build(scheme="wss", host=host, port=port),
+                ssl=ssl_context,
+                headers={"Authorization": f"Basic {auth_b64}"},
+            ) as ws,
+        ):
             await ws.close()
     except aiohttp.WSServerHandshakeError as err:
         if err.status == 401:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -334,6 +334,39 @@ async def test_reconfigure_cannot_connect(hass: HomeAssistant) -> None:
     assert result["errors"] == {"base": "cannot_connect"}
 
 
+async def test_reconfigure_rejects_other_entry_host(
+    hass: HomeAssistant, mock_setup_entry
+) -> None:
+    """Reconfiguring onto another entry's host aborts."""
+    other_host = "192.168.1.200"
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=other_host,
+        data={
+            CONF_HOST: other_host,
+            CONF_PORT: MOCK_PORT,
+            CONF_PASSWORD: MOCK_PASSWORD,
+        },
+    ).add_to_hass(hass)
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id=MOCK_HOST,
+        data={CONF_HOST: MOCK_HOST, CONF_PORT: MOCK_PORT, CONF_PASSWORD: MOCK_PASSWORD},
+    )
+    entry.add_to_hass(hass)
+
+    result = await entry.start_reconfigure_flow(hass)
+    with patch(PATCH_TRY_CONNECT, return_value=None):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_HOST: other_host, CONF_PORT: MOCK_PORT, CONF_PASSWORD: MOCK_PASSWORD},
+        )
+
+    assert result["type"] == "abort"
+    assert result["reason"] == "already_configured"
+
+
 # ---------------------------------------------------------------------------
 # Import flow (YAML)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two `config_flow.py` fixes from the Copilot review on the core PR (home-assistant/core#176988):

- **Unbounded connection probe.** `_async_try_connect` set `aiohttp.ClientWSTimeout(ws_receive=10)`, which only limits `receive()`. This probe never receives a frame, so an unreachable host waited on aiohttp's much longer session default. The attempt is now wrapped in `asyncio.timeout(10)` and the `ws_receive` timeout dropped.
- **Reconfigure could duplicate a gateway.** `async_step_reconfigure` never checked existing entries, so a second entry could be pointed at an already configured gateway. It now runs `_async_abort_entries_match` when the host changes to one another entry uses (skipped when the host is unchanged, so an ordinary save is unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
