### PR TITLE
Type-narrow device_entry before reading sw_version

### DIFF
--- a/custom_components/gardena_smart_local_preview/entity.py
+++ b/custom_components/gardena_smart_local_preview/entity.py
@@ -133,14 +133,15 @@ class GardenaEntity(CoordinatorEntity[GardenaSmartLocalCoordinator]):
         version until Home Assistant restarts.
         """
         device = self.coordinator.data.get(self._device.id)
+        device_entry = self.device_entry
         if (
             device
             and device.software_version
-            and self.device_entry
-            and self.device_entry.sw_version != device.software_version
+            and isinstance(device_entry, dr.DeviceEntry)
+            and device_entry.sw_version != device.software_version
         ):
             dr.async_get(self.hass).async_update_device(
-                self.device_entry.id, sw_version=device.software_version
+                device_entry.id, sw_version=device.software_version
             )
         super()._handle_coordinator_update()
 


### PR DESCRIPTION
`Entity.device_entry` is typed `DeviceEntry | ChildDeviceEntry | None`. `ChildDeviceEntry` has no `sw_version`, so the firmware-version sync in `_handle_coordinator_update` is not type-safe. Guard it with an `isinstance(device_entry, dr.DeviceEntry)` check.

Raised by the Copilot review on the core PR (home-assistant/core#176988), where the current mypy check fails on this access; fixed there the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
